### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm run build
+      - run: npm ci && npm run build
       - run: npm install -g firebase-tools
       - run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"


### PR DESCRIPTION
## Summary
- update deploy workflow to run `npm ci` and `npm run build` in a single step

## Testing
- `npm ci` *(fails: Command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6844171d0d1883318c96ce639bb1cada