### PR TITLE
Add lineup transformation tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import ChantCard from './components/ChantCard';
 import LyricsSection from './components/LyricsSection';
 import TeamChantVideo from './components/TeamChantVideo';
 import { getTeamInfo, getPositionKorean, getBattingOrder } from './utils/team';
+import { transformLineups } from './utils/lineupTransformer';
 
 // simple helper to avoid logs in production
 const debugLog = (...args) => {
@@ -202,17 +203,7 @@ const fetchJsonData = async () => {
         })
       : [];
 
-    const parsedLineups = Array.isArray(lineupsData)
-      ? lineupsData.map(game => ({
-          id: game.id,
-          date: game.date,
-          team: game.team,
-          home: game.home,
-          away: game.away,
-          location: game.location,
-          lineup: Array.isArray(game.lineup) ? game.lineup.sort((a, b) => a.order - b.order) : []
-        }))
-      : [];
+    const parsedLineups = transformLineups(lineupsData);
 
     const parsedTeamChants = Array.isArray(teamChantsData)
       ? teamChantsData.map((chant, idx) => ({

--- a/src/utils/lineupTransformer.js
+++ b/src/utils/lineupTransformer.js
@@ -1,0 +1,50 @@
+export const transformLineups = (lineupsData) => {
+  if (Array.isArray(lineupsData)) {
+    return lineupsData.map(game => ({
+      id: game.id,
+      date: game.date,
+      team: game.team,
+      home: game.home,
+      away: game.away,
+      location: game.location,
+      lineup: Array.isArray(game.lineup) ? [...game.lineup].sort((a,b) => a.order - b.order) : []
+    }));
+  }
+
+  if (lineupsData && Array.isArray(lineupsData.games)) {
+    const games = lineupsData.games;
+    const result = [];
+    games.forEach(game => {
+      const dateRaw = game.game_code ? game.game_code.slice(0,8) : '';
+      const formattedDate = dateRaw ? `${dateRaw.slice(0,4)}-${dateRaw.slice(4,6)}-${dateRaw.slice(6,8)}` : '';
+      const homeTeam = game.teams.find(t => t.is_home)?.name || '';
+      const awayTeam = game.teams.find(t => !t.is_home)?.name || '';
+      const team1 = game.starting_lineups.team_1;
+      const team2 = game.starting_lineups.team_2;
+
+      const makeLineup = (teamData, isHome) => ({
+        id: `${formattedDate}_${teamData.team_name}`,
+        date: formattedDate,
+        team: teamData.team_name,
+        home: isHome ? teamData.team_name : homeTeam,
+        away: isHome ? awayTeam : teamData.team_name,
+        location: '',
+        lineup: [
+          ...teamData.starting_batters.map(b => ({
+            order: b.batting_order,
+            playerName: b.name,
+            position: b.position
+          })),
+          { order: 10, playerName: teamData.starting_pitcher.name, position: '투수' }
+        ].sort((a,b) => a.order - b.order)
+      });
+
+      const isTeam1Home = team1.team_name === homeTeam;
+      result.push(makeLineup(team1, isTeam1Home));
+      result.push(makeLineup(team2, !isTeam1Home));
+    });
+    return result;
+  }
+
+  return [];
+};

--- a/src/utils/lineupTransformer.test.js
+++ b/src/utils/lineupTransformer.test.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { transformLineups } from './lineupTransformer';
+
+test('transforms crawler JSON lineup correctly', () => {
+  const filePath = path.join(__dirname, '..', '..', 'public', 'data', 'kbo_crawler_data', '2025-03-25_20250325HHLG02025_한화-LG.json');
+  const json = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const lineups = transformLineups(json);
+
+  const hanwha = lineups.find(g => g.team === '한화');
+  expect(hanwha.lineup.map(p => p.playerName)).toEqual([
+    '김태연', '문현빈', '플로리얼', '노시환', '채은성', '안치홍', '임종찬', '최재훈', '심우준', '류현진'
+  ]);
+
+  const lg = lineups.find(g => g.team === 'LG');
+  expect(lg.lineup.map(p => p.playerName)).toEqual([
+    '홍창기', '송찬의', '오스틴', '문보경', '오지환', '박동원', '문정빈', '박해민', '구본혁', '에르난데스'
+  ]);
+});


### PR DESCRIPTION
## Summary
- support crawler-style lineups via `transformLineups`
- use new transformer inside `fetchJsonData`
- test lineup transformation with sample crawler JSON

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c24cb27c48331a93bd8859e65164e