### PR TITLE
Update lineup location handling

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -60,7 +60,8 @@ const LineupTab = ({
                   {currentGame.home} vs {currentGame.away}
                 </h3>
                 <p className="text-sm text-blue-600">
-                  {currentGame.location} • {formatDateKorean(currentGame.date)}
+                  {currentGame.location ? `${currentGame.location} • ` : ''}
+                  {formatDateKorean(currentGame.date)}
                 </p>
                 <p className="text-sm text-blue-600">
                   {currentLineup.length}개 응원가 • 총 재생시간 약 {Math.ceil(currentLineup.length * 2)}분

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -97,7 +97,7 @@ const useKboData = () => {
             team: game.team,
             home: game.home,
             away: game.away,
-            location: game.location,
+            location: game.location || '',
             lineup: Array.isArray(game.lineup)
               ? game.lineup.sort((a, b) => a.order - b.order)
               : [],


### PR DESCRIPTION
## Summary
- default lineup location to blank when constructing game data
- only show location bullet if lineup has a location

## Testing
- `npm test --silent --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2d9852608331949ff7309fb9f458