### PR TITLE
Update lineup data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ JikgwanGaja is a React application for browsing KBO lineups, player walk-up song
 ## Updating JSON data
 
 Edit the JSON files directly inside `public/data/` and commit your changes.
-The app reads the JSON files from this folder at runtime.
+Lineup information is now stored in `public/data/kbo_crawler_data` where
+`index.json` lists the individual game files.  The app reads these JSON files
+at runtime.
 
 ## Basic npm commands
 

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -93,7 +93,9 @@ const useKboData = () => {
       const lineupFiles = Array.isArray(lineupIndex)
         ? await Promise.all(
             lineupIndex.map((file) =>
-              fetch(`${base}/data/kbo_crawler_data/${file}`).then((res) => res.json())
+              fetch(
+                `${base}/data/kbo_crawler_data/${encodeURIComponent(file)}`
+              ).then((res) => res.json())
             )
           )
         : [];


### PR DESCRIPTION
## Summary
- fetch lineup files from `kbo_crawler_data` using encoded filenames
- document new lineup data location in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e9fbe54833194027ca8f787dab4