### PR TITLE
Unmute YouTube player by default

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -540,7 +540,7 @@ const getSortedChants = () => {
       height: '200',
       playerVars: {
         autoplay: 0,
-        mute: 1,
+        mute: 0,
         controls: 1,
         rel: 0,
       }
@@ -669,7 +669,7 @@ const getSortedChants = () => {
       height: '235',
       playerVars: {
         autoplay: 1,
-        mute: 1,
+        mute: 0,
         controls: 1,
         rel: 0,
       }


### PR DESCRIPTION
## Summary
- enable sound on YouTube players by default by setting `mute` to `0`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b3d15fc8331b23fd257777b4d3f