### PR TITLE
Fix play controls for YouTube videos

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,6 +85,16 @@ const JikgwanGaja = () => {
     }
     localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
   }, [isDarkMode]);
+
+  useEffect(() => {
+    if (playerRef.current) {
+      if (isPlaying) {
+        playerRef.current.playVideo();
+      } else {
+        playerRef.current.pauseVideo();
+      }
+    }
+  }, [isPlaying]);
   
   const handleChange = (e) => {
     const newValue = e.target.value;
@@ -540,7 +550,7 @@ const getSortedChants = () => {
       height: '200',
       playerVars: {
         autoplay: 0,
-        mute: 1,
+        mute: 0,
         controls: 1,
         rel: 0,
       }
@@ -668,8 +678,8 @@ const getSortedChants = () => {
       width: '100%',
       height: '235',
       playerVars: {
-        autoplay: 1,
-        mute: 1,
+        autoplay: 0,
+        mute: 0,
         controls: 1,
         rel: 0,
       }
@@ -773,6 +783,9 @@ const getSortedChants = () => {
                 opts={opts}
                 onReady={(event) => {
                   playerRef.current = event.target;
+                  if (isPlaying) {
+                    event.target.playVideo();
+                  }
                 }}
               />
             ) : (
@@ -963,6 +976,7 @@ const getSortedChants = () => {
             setCurrentPlayer={setCurrentPlayer}
             setPlaySource={setPlaySource}
             setShowPlayer={setShowPlayer}
+            setIsPlaying={setIsPlaying}
             toggleLike={toggleLike}
             likedSongs={likedSongs}
             handleShare={handleShare}
@@ -1248,6 +1262,7 @@ const getSortedChants = () => {
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
+                setIsPlaying={setIsPlaying}
                 toggleLike={toggleLike}
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -8,6 +8,7 @@ const ChantCard = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
+  setIsPlaying,
   toggleLike,
   likedSongs,
   handleShare
@@ -73,6 +74,7 @@ const ChantCard = ({
             setCurrentPlayer(playerIndex);
             setPlaySource('explore');
             setShowPlayer(true);
+            setIsPlaying(true);
           }
         }}
       >

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -18,6 +18,7 @@ const LineupTab = ({
   setCurrentLineupIndex,
   setPlaySource,
   setShowPlayer,
+  setIsPlaying,
   toggleLike,
   gameLineups,
   setSelectedDate,
@@ -88,6 +89,7 @@ const LineupTab = ({
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
+                setIsPlaying={setIsPlaying}
                 toggleLike={toggleLike}
                 likedSongs={likedSongs}
               />

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -11,6 +11,7 @@ const PlayerCard = ({
   setCurrentLineupIndex,
   setPlaySource,
   setShowPlayer,
+  setIsPlaying,
   toggleLike,
   likedSongs
 }) => (
@@ -49,6 +50,7 @@ const PlayerCard = ({
             setCurrentLineupIndex(index);
             setPlaySource('lineup');
             setShowPlayer(true);
+            setIsPlaying(true);
           }}
           className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
         >


### PR DESCRIPTION
## Summary
- ensure TeamChantsTab and PlayerTab videos start unmuted
- disable autoplay so Play button controls playback
- sync play/pause state with the YouTube player
- automatically start playback when selecting a chant or lineup player

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3aa235548331976227ffd0f675e4