### PR TITLE
Enable card click to open player screen

### DIFF
--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -11,8 +11,21 @@ const ChantCard = ({
   toggleLike,
   likedSongs,
   handleShare
-}) => (
-  <div className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200">
+}) => {
+  const openPlayer = () => {
+    const playerIndex = playerSongs.findIndex(c => c.id === chant.id);
+    if (playerIndex !== -1) {
+      setCurrentPlayer(playerIndex);
+      setPlaySource('explore');
+      setShowPlayer(true);
+    }
+  };
+
+  return (
+    <div
+      onClick={openPlayer}
+      className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
+    >
     <div className="flex items-start justify-between mb-4">
       <div className="flex-1">
         <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{chant.playerName}</h3>
@@ -67,29 +80,32 @@ const ChantCard = ({
     <div className="flex items-center gap-2">
       <button
         className="flex-1 bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-3 px-4 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
-        onClick={() => {
-          const playerIndex = playerSongs.findIndex(c => c.id === chant.id);
-          if (playerIndex !== -1) {
-            setCurrentPlayer(playerIndex);
-            setPlaySource('explore');
-            setShowPlayer(true);
-          }
+        onClick={(e) => {
+          e.stopPropagation();
+          openPlayer();
         }}
       >
         <Play className="w-4 h-4" />
         재생
       </button>
       <button
-        onClick={() => handleShare(chant)}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleShare(chant);
+        }}
         className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
       >
         <Share2 className="w-4 h-4 text-gray-600" />
       </button>
-      <button className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all">
+      <button
+        onClick={(e) => e.stopPropagation()}
+        className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
+      >
         <Plus className="w-4 h-4 text-gray-600" />
       </button>
     </div>
   </div>
-);
+  );
+};
 
 export default ChantCard;


### PR DESCRIPTION
## Summary
- make `ChantCard` clickable
- open player screen when a chant card is clicked
- prevent card click when clicking on inner buttons

## Testing
- `CI=true npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bbfdfe483319ed355aa072e1eb7