### PR TITLE
Implement lineup sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ npm run build # build for production
 ```
 
 Running these commands requires **Node.js 20 or later**.
+
+## Sharing lineups
+
+Use the "오늘의 라인업 공유하기" button in the lineup tab to share or copy the
+current team's lineup.

--- a/src/App.js
+++ b/src/App.js
@@ -521,6 +521,33 @@ const getSortedChants = () => {
     }
   };
 
+  const handleShareLineup = async () => {
+    const lineupText = currentLineup
+      .map((p, idx) => `${idx + 1}. ${p.playerName} (${p.position})`)
+      .join('\n');
+    const text = `${selectedTeam} 오늘의 라인업\n${lineupText}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: `${selectedTeam} 라인업`, text });
+        return;
+      } catch (err) {
+        console.error('Share failed', err);
+      }
+    }
+
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(text);
+        alert('라인업이 클립보드에 복사되었습니다.');
+      } catch (err) {
+        alert('라인업 복사에 실패했습니다.');
+      }
+    } else {
+      alert('공유 기능을 지원하지 않는 브라우저입니다.');
+    }
+  };
+
 
 
   const TeamChantsTab = () => {
@@ -1251,6 +1278,7 @@ const getSortedChants = () => {
                 toggleLike={toggleLike}
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}
+                handleShareLineup={handleShareLineup}
               />
             )}
             {activeTab === 'teamChants' && <TeamChantsTab />}

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PlayerCard from './PlayerCard';
-import { RefreshCw, AlertCircle, Music, Circle } from 'lucide-react';
+import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
 
 const LineupTab = ({
   currentLineup,
@@ -21,6 +21,7 @@ const LineupTab = ({
   toggleLike,
   gameLineups,
   setSelectedDate,
+  handleShareLineup,
 }) => {
   const currentGame = getCurrentGame();
 
@@ -28,13 +29,22 @@ const LineupTab = ({
     <div className="space-y-3">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-xl font-bold text-gray-800">오늘의 라인업</h2>
-        <button
-          onClick={fetchJsonData}
-          className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors"
-        >
-          <RefreshCw className="w-4 h-4" />
-          새로고침
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleShareLineup}
+            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 transition-colors"
+          >
+            <Share2 className="w-4 h-4" />
+            오늘의 라인업 공유하기
+          </button>
+          <button
+            onClick={fetchJsonData}
+            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors"
+          >
+            <RefreshCw className="w-4 h-4" />
+            새로고침
+          </button>
+        </div>
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
- add `handleShareLineup` function to share today's lineup
- pass lineup share handler to `LineupTab`
- add share button next to refresh in lineup tab
- document lineup sharing in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c42a1070483318534faf54dcda818