### PR TITLE
Fix stray brace in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -555,7 +555,6 @@ const getSortedChants = () => {
 
   
 
-  };
 
 
   // 날짜 옵션 생성 함수


### PR DESCRIPTION
## Summary
- remove extraneous closing brace after `handleShareLineup`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c47efed9c8331b8b029615af9b1a7