### PR TITLE
Fix daily crawler commit step

### DIFF
--- a/.github/workflows/daily-crawl.yml
+++ b/.github/workflows/daily-crawl.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add public/data/kbo_crawler_data kbo_crawler.log
-          git commit -m "Daily lineup update and crawler log" || echo "No changes to commit"
+          git add public/data/kbo_crawler_data
+          git commit -m "Daily lineup update" || echo "No changes to commit"
           git pull origin main
           git push origin main
           fi


### PR DESCRIPTION
## Summary
- avoid adding kbo_crawler.log which is ignored by .gitignore

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed9f764588331876c55533f899ae0