### PR TITLE
Update daily crawl workflow pull strategy

### DIFF
--- a/.github/workflows/daily-crawl.yml
+++ b/.github/workflows/daily-crawl.yml
@@ -80,6 +80,5 @@ jobs:
           git config --global user.email 'actions@github.com'
           git add public/data/kbo_crawler_data
           git commit -m "Daily lineup update" || echo "No changes to commit"
-          git pull origin main
+          git pull --rebase origin main
           git push origin main
-          fi


### PR DESCRIPTION
## Summary
- fix pull strategy by rebasing before pushing
- remove stray shell token

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851760e8174833197375c46c740b0bc