### PR TITLE
Automatically rebuild lineup index after crawler runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ JikgwanGaja is a React application for browsing KBO lineups, player walk-up song
 
 ## Updating JSON data
 
-Edit the JSON files directly inside `public/data/` or generate new lineup files using the crawler described below. After adding lineup files inside `public/data/kbo_crawler_data`, run:
+Edit the JSON files directly inside `public/data/` or generate new lineup files using the crawler described below. The crawler automatically rebuilds `public/data/kbo_crawler_data/index.json` when it finishes, but you can run the indexing script manually:
 
 ```bash
 npm run build-lineup-index
 ```
-
-to refresh `public/data/kbo_crawler_data/index.json`.
 
 ## Crawling lineups
 
@@ -28,7 +26,7 @@ For an **incremental** update of the last N days (3 by default):
 python public/kbo_crawler.py --mode incremental --days 3 --save_dir public/data/kbo_crawler_data
 ```
 
-After crawling, run `npm run build-lineup-index` to update the game index.
+The crawler saves each game's lineup JSON files and then rebuilds the index automatically.
 
 ## Basic npm commands
 

--- a/public/kbo_crawler.py
+++ b/public/kbo_crawler.py
@@ -16,6 +16,7 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 import os
 import argparse
 import logging
+import subprocess
 
 # 로깅 설정
 logging.basicConfig(
@@ -642,6 +643,16 @@ if __name__ == "__main__":
         print(f"\n🚀 크롤링 날짜: {date_list}")
         crawler.crawl_and_save_by_dates(date_list)
         print("\n🎉 모든 경기별 파일 저장 완료!")
+
+        # Save a rebuilt index of all lineup JSON files
+        index_script = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'generateLineupIndex.js')
+        try:
+            subprocess.run(['node', index_script], check=True)
+            print("🔃 라인업 인덱스 갱신 완료")
+        except FileNotFoundError:
+            print("❌ Node.js를 찾을 수 없어 인덱스 갱신을 건너뜁니다.")
+        except subprocess.CalledProcessError as e:
+            print(f"❌ 라인업 인덱스 갱신 실패: {e}")
     except Exception as e:
         print(f"❌ 오류 발생: {e}")
     finally:


### PR DESCRIPTION
## Summary
- call Node script to rebuild `index.json` when `kbo_crawler.py` finishes
- document automatic index generation in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build-lineup-index`

------
https://chatgpt.com/codex/tasks/task_e_6852d23233d88331af1024d437b52519