### PR TITLE
Add workflow to manually rebuild lineup index

### DIFF
--- a/.github/workflows/rebuild-index.yml
+++ b/.github/workflows/rebuild-index.yml
@@ -1,0 +1,34 @@
+name: Manual lineup index rebuild
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rebuild-index:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Rebuild lineup index
+        run: npm run build-lineup-index
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/kbo_crawler_data/index.json
+          git commit -m "Rebuild lineup index" || echo "No changes to commit"
+          git pull --rebase origin main
+          git push origin main


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `rebuild-index.yml` to rebuild the lineup index manually

## Testing
- `npm test --silent -- --watchAll=false` *(fails: `react-scripts` not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853c41155dc833190af64060f72cf6b