### PR TITLE
Run index rebuild automatically after crawler

### DIFF
--- a/.github/workflows/rebuild-index.yml
+++ b/.github/workflows/rebuild-index.yml
@@ -2,9 +2,14 @@ name: Manual lineup index rebuild
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Daily KBO crawl"]
+    types:
+      - completed
 
 jobs:
   rebuild-index:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- trigger `rebuild-index.yml` when `Daily KBO crawl` completes successfully

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f12ca12883318685e8d4a40d534e