### PR TITLE
Add daily player crawler

### DIFF
--- a/.github/workflows/daily-crawl.yml
+++ b/.github/workflows/daily-crawl.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y google-chrome-stable
           
-      - name: Run crawler with retry
+      - name: Run lineup crawler with retry
         run: |
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
@@ -70,7 +70,12 @@ jobs:
               fi
             fi
           done
-        
+
+      - name: Run player crawler
+        run: |
+          export DISPLAY=:99
+          python public/kbo_players_crawler.py
+
       - name: Rebuild lineup index
         run: npm run build-lineup-index
         
@@ -78,7 +83,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add public/data/kbo_crawler_data
-          git commit -m "Daily lineup update" || echo "No changes to commit"
+          git add public/data/kbo_crawler_data public/data/kboPlayers.json
+          git commit -m "Daily data update" || echo "No changes to commit"
           git pull --rebase origin main
           git push origin main

--- a/README.md
+++ b/README.md
@@ -29,12 +29,26 @@ python public/kbo_crawler.py --mode incremental --days 3 --save_dir public/data/
 
 The crawler saves each game's lineup JSON files and then rebuilds the index automatically.
 
+## Crawling player info
+
+`public/kbo_players_crawler.py` scrapes basic player details from the KBO web site.
+It requires Selenium with Chrome and writes the results to `public/data/kboPlayers.json`.
+The crawler records each player's school instead of the `updatedAt` timestamp found in
+older data files.
+
+Run the crawler:
+
+```bash
+python public/kbo_players_crawler.py
+```
+
 ## Automated daily crawl
 
 The GitHub Actions workflow at `.github/workflows/daily-crawl.yml` runs every
-day to fetch new lineups. The workflow rebuilds
-`public/data/kbo_crawler_data/index.json` and commits the updated files back to
-the repository automatically.
+day to fetch new lineups **and** the full player list. The workflow rebuilds
+`public/data/kbo_crawler_data/index.json` and updates
+`public/data/kboPlayers.json`, committing any changes back to the repository
+automatically.
 
 ## Basic npm commands
 

--- a/public/kbo_players_crawler.py
+++ b/public/kbo_players_crawler.py
@@ -1,0 +1,109 @@
+import json
+import time
+from datetime import datetime
+from bs4 import BeautifulSoup
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import Select
+from selenium.webdriver.common.by import By
+
+TEAM_CODES = {
+    "HH": "한화",
+    "OB": "두산",
+    "SS": "삼성",
+    "LT": "롯데",
+    "LG": "LG",
+    "WO": "키움",
+    "NC": "NC",
+    "HT": "KIA",
+    "SK": "SSG",
+    "KT": "KT",
+}
+
+
+def _parse_date(text: str) -> str:
+    """Convert 'YYYY-MM-DD' into ISO format used in data."""
+    try:
+        return datetime.strptime(text, "%Y-%m-%d").isoformat() + "Z"
+    except ValueError:
+        return text
+
+
+def _scrape_team(driver: webdriver.Chrome, code: str) -> list:
+    select = Select(driver.find_element(By.ID, "cphContents_cphContents_cphContents_ddlTeam"))
+    select.select_by_value(code)
+    time.sleep(2)
+    players = []
+
+    while True:
+        soup = BeautifulSoup(driver.page_source, "html.parser")
+        table = soup.find("table", class_="tEx")
+        if not table:
+            break
+        rows = table.find("tbody").find_all("tr")
+        for row in rows:
+            cols = [c.get_text(strip=True) for c in row.find_all("td")]
+            if len(cols) < 7:
+                continue
+
+            # Some pages omit the throw/bat column
+            if len(cols) == 7:
+                number, name, team, position, birth, body, school = cols
+                throwbat = ""
+            else:
+                number, name, team, position, throwbat, birth, body, school = cols[:8]
+
+            player = {
+                "teamCode": code,
+                "teamName": TEAM_CODES.get(code, ""),
+                "number": number,
+                "playerName": name,
+                "position": position,
+                "throwBat": throwbat,
+                "birth": _parse_date(birth),
+                "body": body,
+                "school": school,
+            }
+            players.append(player)
+        try:
+            next_btn = driver.find_element(By.ID, "cphContents_cphContents_cphContents_ucPager_btnNext")
+            if "disabled" in next_btn.get_attribute("class"):
+                break
+            next_btn.click()
+            time.sleep(1.5)
+        except Exception:
+            break
+
+    return players
+
+
+def crawl_players() -> list:
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument(
+        "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+
+    driver = webdriver.Chrome(options=options)
+    driver.get("https://www.koreabaseball.com/Record/Player/Basic/PlayerBasic.aspx")
+    time.sleep(2)
+
+    all_players = []
+    for code in TEAM_CODES:
+        all_players.extend(_scrape_team(driver, code))
+
+    driver.quit()
+    return all_players
+
+
+def save_players(players: list, path: str = "public/data/kboPlayers.json") -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(players, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    players = crawl_players()
+    save_players(players)
+    print(f"Saved {len(players)} players")


### PR DESCRIPTION
## Summary
- make player crawler resilient to column variations and set user-agent
- update README with daily crawl and player info changes
- run the new player crawler in the daily GitHub workflow

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858044197108331bbdbe11b748440fe