### PR TITLE
Remove lineup count display from LineupTab

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -71,9 +71,6 @@ const LineupTab = ({
                 <p className="text-sm text-blue-600">
                   {currentGame.location} • {formatDateKorean(currentGame.date)}
                 </p>
-                <p className="text-sm text-blue-600">
-                  {currentLineup.length}개 응원가 • 총 재생시간 약 {Math.ceil(currentLineup.length * 2)}분
-                </p>
               </div>
               <button
                 onClick={handlePlayAll}


### PR DESCRIPTION
## Summary
- remove the `<p>` element that displayed the number of songs in the match info block of `LineupTab`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580d43d5508331a4aff799f9110b65