### PR TITLE
Remove likes display from ChantCard

### DIFF
--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -53,11 +53,6 @@ const ChantCard = ({
               </span>
             </>
           )}
-          <span className="text-gray-300 dark:text-gray-600">•</span>
-          <div className="flex items-center gap-1">
-            <Heart className="w-3 h-3 text-red-400" />
-            <span className="text-xs text-gray-500 dark:text-gray-400">{chant.likes.toLocaleString()}</span>
-          </div>
         </div>
       </div>
       <button


### PR DESCRIPTION
## Summary
- clean up `ChantCard` metadata row by removing likes count and icon

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580d434a0083319b093739d18da873