### PR TITLE
Remove popularity sorting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -419,17 +419,11 @@ const JikgwanGaja = () => {
     setLikedSongs(newLiked);
   };
 
-// getSortedChants 함수 수정
+// getSortedChants 함수 수정 - 가나다순 정렬만 지원
 const getSortedChants = () => {
-  let sorted = [...playerSongs];
-  switch(sortBy) {
-    case 'popular':
-      return sorted.sort((a, b) => b.likes - a.likes); // 좋아요 순
-    case 'name':
-      return sorted.sort((a, b) => a.playerName.localeCompare(b.playerName, 'ko')); // 가나다순
-    default:
-      return sorted;
-  }
+  return [...playerSongs].sort((a, b) =>
+    a.playerName.localeCompare(b.playerName, 'ko')
+  );
 };
 
   const filteredChants = getSortedChants().filter(chant => {
@@ -862,7 +856,6 @@ const getSortedChants = () => {
                 handleCompositionEnd={handleCompositionEnd}
                 exploreTeamFilter={exploreTeamFilter}
                 setExploreTeamFilter={setExploreTeamFilter}
-                sortBy={sortBy}
                 setSortBy={setSortBy}
                 playerSongs={playerSongs}
                 likedSongs={likedSongs}

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   Search,
   Filter,
-  Heart,
   Circle,
   RefreshCw,
   AlertCircle,
@@ -15,7 +14,6 @@ const ExploreTab = ({
   handleCompositionEnd,
   exploreTeamFilter,
   setExploreTeamFilter,
-  sortBy,
   setSortBy,
   playerSongs,
   likedSongs,
@@ -70,23 +68,13 @@ const ExploreTab = ({
         </select>
       </div>
       <div className="flex items-center gap-3 overflow-x-auto pb-3">
-        {[
-          { key: 'popular', label: '인기순', icon: Heart, color: 'from-red-500 to-pink-500' },
-          { key: 'name', label: '가나다순', icon: Circle, color: 'from-blue-500 to-indigo-500' },
-        ].map(({ key, label, icon: Icon, color }) => (
-          <button
-            key={key}
-            onClick={() => setSortBy(key)}
-            className={`flex items-center gap-2 px-5 py-3 rounded-full whitespace-nowrap transition-all font-medium ${
-              sortBy === key
-                ? `bg-gradient-to-r ${color} text-white shadow-lg shadow-gray-300 scale-105`
-                : 'bg-white text-gray-700 hover:bg-gray-50 border border-gray-200 hover:border-gray-300 hover:shadow-sm'
-            }`}
-          >
-            <Icon className="w-4 h-4" />
-            {label}
-          </button>
-        ))}
+        <button
+          onClick={() => setSortBy('name')}
+          className="flex items-center gap-2 px-5 py-3 rounded-full whitespace-nowrap transition-all font-medium bg-white text-gray-700 hover:bg-gray-50 border border-gray-200 hover:border-gray-300 hover:shadow-sm"
+        >
+          <Circle className="w-4 h-4" />
+          가나다순
+        </button>
       </div>
     </div>
     {/* 통계 카드 */}


### PR DESCRIPTION
## Summary
- remove popularity button in ExploreTab
- stop passing sortBy to ExploreTab
- always sort chants alphabetically

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580d4250908331be109dfdcee88ece