### PR TITLE
Add dark mode support for UI elements

### DIFF
--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -95,13 +95,13 @@ const ChantCard = ({
         }}
         className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
       >
-        <Share2 className="w-4 h-4 text-gray-600" />
+        <Share2 className="w-4 h-4 text-gray-600 dark:text-gray-400" />
       </button>
       <button
         onClick={(e) => e.stopPropagation()}
         className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
       >
-        <Plus className="w-4 h-4 text-gray-600" />
+        <Plus className="w-4 h-4 text-gray-600 dark:text-gray-400" />
       </button>
     </div>
   </div>

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -45,7 +45,7 @@ const ExploreTab = ({
           onChange={handleChange}
           onCompositionStart={handleCompositionStart}
           onCompositionEnd={handleCompositionEnd}
-          className="w-full pl-10 pr-4 py-3 border border-gray-200 rounded-xl focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent bg-gray-50"
+          className="w-full pl-10 pr-4 py-3 border border-gray-200 rounded-xl focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent bg-gray-50 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
         />
       </div>
       {/* 팀 필터 추가 */}
@@ -54,7 +54,7 @@ const ExploreTab = ({
         <select
           value={exploreTeamFilter}
           onChange={(e) => setExploreTeamFilter(e.target.value)}
-          className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent shadow-sm"
+          className="bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent shadow-sm dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
         >
           <option value="전체">전체 팀</option>
           <option value="KIA">KIA 타이거즈</option>
@@ -114,7 +114,7 @@ const ExploreTab = ({
     {/* 응원가 목록 */}
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold">
+        <h2 className="text-lg font-bold dark:text-gray-100">
           {showOnlyLiked
             ? '❤️ 좋아한 응원가'
             : exploreTeamFilter === '전체'
@@ -122,7 +122,7 @@ const ExploreTab = ({
             : `${exploreTeamFilter} 응원가`}
         </h2>
         <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500">{filteredChants.length}개</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">{filteredChants.length}개</span>
           <button
             onClick={() => {
               const today = new Date();
@@ -139,8 +139,8 @@ const ExploreTab = ({
         </div>
       </div>
       {error && (
-        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3">
-          <div className="flex items-center gap-2 text-yellow-800 text-sm">
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 dark:bg-yellow-900 dark:border-yellow-700">
+          <div className="flex items-center gap-2 text-yellow-800 text-sm dark:text-yellow-100">
             <AlertCircle className="w-4 h-4" />
             <span>데이터 로드 오류: 임시 데이터 표시 중</span>
           </div>
@@ -160,7 +160,7 @@ const ExploreTab = ({
         />
       ))}
       {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체' || showOnlyLiked) && !isComposing && (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>
             {showOnlyLiked

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -28,18 +28,18 @@ const LineupTab = ({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-gray-800">오늘의 라인업</h2>
+        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">오늘의 라인업</h2>
         <div className="flex items-center gap-2">
           <button
             onClick={handleShareLineup}
-            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <Share2 className="w-4 h-4" />
             공유하기
           </button>
           <button
             onClick={fetchJsonData}
-            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -47,8 +47,8 @@ const LineupTab = ({
       </div>
 
       {error && (
-        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4">
-          <div className="flex items-center gap-2 text-yellow-800">
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4 dark:bg-yellow-900 dark:border-yellow-700">
+          <div className="flex items-center gap-2 text-yellow-800 dark:text-yellow-100">
             <AlertCircle className="w-5 h-5" />
             <span className="text-sm">데이터 로드 오류: {error}</span>
           </div>
@@ -58,20 +58,20 @@ const LineupTab = ({
       {loading ? (
         <div className="text-center py-8">
           <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-blue-500" />
-          <p className="text-gray-600">데이터를 불러오는 중...</p>
+          <p className="text-gray-600 dark:text-gray-400">데이터를 불러오는 중...</p>
         </div>
       ) : currentGame ? (
         <>
-          <div className="bg-blue-50 rounded-lg p-4 mb-4">
+          <div className="bg-blue-50 rounded-lg p-4 mb-4 dark:bg-gray-800">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="font-semibold text-blue-800">
+                <h3 className="font-semibold text-blue-800 dark:text-blue-100">
                   {currentGame.home} vs {currentGame.away}
                 </h3>
-                <p className="text-sm text-blue-600">
+                <p className="text-sm text-blue-600 dark:text-blue-200">
                   {currentGame.location} • {formatDateKorean(currentGame.date)}
                 </p>
-                <p className="text-sm text-blue-600">
+                <p className="text-sm text-blue-600 dark:text-blue-200">
                   {currentLineup.length}개 응원가 • 총 재생시간 약 {Math.ceil(currentLineup.length * 2)}분
                 </p>
               </div>
@@ -102,17 +102,17 @@ const LineupTab = ({
               />
             ))
           ) : (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
               <Music className="w-12 h-12 mx-auto mb-4 opacity-50" />
               <p>이 경기의 라인업 정보가 없습니다</p>
             </div>
           )}
         </>
       ) : (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Circle className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>라인업 발표 전입니다</p>
-          <p className="text-sm mt-2">경기 시작 전에 라인업이 발표됩니다</p>
+          <p className="text-sm mt-2 dark:text-gray-400">경기 시작 전에 라인업이 발표됩니다</p>
 
           <button
             onClick={() => {

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -74,15 +74,23 @@ const PlayerTab = ({
             {currentChant.playerName}
           </h2>
           {!hasPlayerData && (
-            <p className="mt-2 text-center text-sm text-gray-500">
-              선수 정보가 없습니다. 곧 업데이트됩니다.
-            </p>
+            <div className="mt-2 text-center space-y-1">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                선수 정보가 없습니다. 곧 업데이트됩니다.
+              </p>
+              <button
+                onClick={handleInfoRequest}
+                className="text-sm text-blue-500 underline dark:text-blue-400"
+              >
+                정보 요청하기
+              </button>
+            </div>
           )}
           {/* 기본 정보 그리드 */}
           <div className="grid grid-cols-2 gap-4 mb-4">
             <div className="space-y-3">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wide">소속팀</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">소속팀</p>
                 <div className="flex items-center gap-2">
                   {getTeamInfo(getDisplayTeam()).logo && (
                     <img
@@ -98,7 +106,7 @@ const PlayerTab = ({
               </div>
               {getDisplayPosition() && (
                 <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wide">포지션</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">포지션</p>
                   <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                     {getPositionKorean(getDisplayPosition())}
                   </p>
@@ -108,7 +116,7 @@ const PlayerTab = ({
             <div className="space-y-3">
               {currentChant.number && (
                 <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wide">등번호</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">등번호</p>
                   <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                     {currentChant.number}번
                   </p>
@@ -116,7 +124,7 @@ const PlayerTab = ({
               )}
               {currentChant.throwBat && (
                 <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wide">투타</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">투타</p>
                   <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                     {currentChant.throwBat}
                   </p>
@@ -128,7 +136,7 @@ const PlayerTab = ({
           <div className="grid grid-cols-1 gap-3 pt-3 border-t border-gray-100 dark:border-gray-700">
             {currentChant.birth && (
               <div className="flex justify-between items-center">
-                <span className="text-sm text-gray-500">생년월일</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">생년월일</span>
                 <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
                   {currentChant.birth.split('T')[0]}
                 </span>
@@ -136,7 +144,7 @@ const PlayerTab = ({
             )}
             {currentChant.body && (
               <div className="flex justify-between items-center">
-                <span className="text-sm text-gray-500">체격</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">체격</span>
                 <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
                   {currentChant.body}
                 </span>
@@ -176,7 +184,7 @@ const PlayerTab = ({
             (playSource === 'explore' && currentPlayer === 0) ||
             (playSource === 'lineup' && currentLineupIndex === 0)
           }
-          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
+          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:hover:bg-gray-600"
         >
           <SkipBack className="w-6 h-6" />
         </button>
@@ -192,7 +200,7 @@ const PlayerTab = ({
             (playSource === 'explore' && currentPlayer === playerSongs.length - 1) ||
             (playSource === 'lineup' && currentLineupIndex === currentLineup.length - 1)
           }
-          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
+          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:hover:bg-gray-600"
         >
           <SkipForward className="w-6 h-6" />
         </button>
@@ -201,19 +209,19 @@ const PlayerTab = ({
       <div className="flex items-center gap-3">
         <button
           onClick={() => handleShare(currentChant)}
-          className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2"
+          className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
         >
           <Share2 className="w-4 h-4" />
           공유
         </button>
         <button
           onClick={handleInfoRequest}
-          className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2"
+          className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
         >
           <Mail className="w-4 h-4" />
           정보 요청
         </button>
-        <button className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2">
+        <button className="flex-1 bg-gray-100 text-gray-700 py-3 px-4 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center gap-2 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">
           <Plus className="w-4 h-4" />
           플레이리스트
         </button>

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -34,11 +34,11 @@ const TeamChantsTab = ({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-2xl font-bold text-gray-900">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
           {selectedTeam} 팀 응원가
         </h2>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
+          <span className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full dark:bg-gray-800 dark:text-gray-400">
             {currentTeamChants.length}개
           </span>
           <button
@@ -50,7 +50,7 @@ const TeamChantsTab = ({
               setSelectedDate(`${yyyy}-${mm}-${dd}`);
               fetchJsonData();
             }}
-            className="p-2 text-blue-600 hover:text-blue-800 transition-colors hover:bg-blue-50 rounded-full"
+            className="p-2 text-blue-600 hover:text-blue-800 transition-colors hover:bg-blue-50 rounded-full dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-blue-900"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -60,13 +60,13 @@ const TeamChantsTab = ({
       {loading ? (
         <div className="text-center py-8">
           <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-blue-500" />
-          <p className="text-gray-600">팀 응원가를 불러오는 중...</p>
+          <p className="text-gray-600 dark:text-gray-400">팀 응원가를 불러오는 중...</p>
         </div>
       ) : currentTeamChants.length === 0 ? (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Trophy className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>{selectedTeam} 팀의 응원가가 없습니다</p>
-          <p className="text-sm mt-2">곧 추가될 예정입니다!</p>
+          <p className="text-sm mt-2 dark:text-gray-400">곧 추가될 예정입니다!</p>
         </div>
       ) : (
         Object.entries(chantsBySituation).map(([situation, chants]) => (


### PR DESCRIPTION
## Summary
- support dark mode for Explore search and team filter
- add dark mode styling to error, headings and messages across tabs
- ensure icons and buttons have dark color variants
- fix missing info request button with dark mode styling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580d46901483318182c67385220d68