### PR TITLE
Disable like system in UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,8 +48,6 @@ const debugLog = (...args) => {
 
 const JikgwanGaja = () => {
   
-  const [showOnlyLiked, setShowOnlyLiked] = useState(false);
-
   const [exploreTeamFilter, setExploreTeamFilter] = useState('전체');
 
   const [currentPlayer, setCurrentPlayer] = useState(0);
@@ -69,7 +67,6 @@ const JikgwanGaja = () => {
 
   const [selectedTeam, setSelectedTeam] = useState('KIA');
   const [sortBy, setSortBy] = useState('name');
-  const [likedSongs, setLikedSongs] = useState(new Set());
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
   
@@ -401,43 +398,16 @@ const JikgwanGaja = () => {
     const dayName = dayNames[date.getDay()];
     return `${month}월 ${day}일(${dayName})`;
   };
-
-  const toggleLike = (songId) => {
-    debugLog('toggleLike 호출됨:', songId);
-    debugLog('현재 likedSongs:', likedSongs);
-    
-    const newLiked = new Set(likedSongs);
-    if (newLiked.has(songId)) {
-      newLiked.delete(songId);
-      debugLog('좋아요 제거:', songId);
-    } else {
-      newLiked.add(songId);
-      debugLog('좋아요 추가:', songId);
-    }
-    
-    debugLog('새로운 likedSongs:', newLiked);
-    setLikedSongs(newLiked);
-  };
-
 // getSortedChants 함수 수정
 const getSortedChants = () => {
   let sorted = [...playerSongs];
-  switch(sortBy) {
-    case 'popular':
-      return sorted.sort((a, b) => b.likes - a.likes); // 좋아요 순
-    case 'name':
-      return sorted.sort((a, b) => a.playerName.localeCompare(b.playerName, 'ko')); // 가나다순
-    default:
-      return sorted;
+  if (sortBy === 'name') {
+    return sorted.sort((a, b) => a.playerName.localeCompare(b.playerName, 'ko'));
   }
+  return sorted;
 };
 
-  const filteredChants = getSortedChants().filter(chant => {
-    // 좋아한 곡만 보기 필터
-    if (showOnlyLiked && !likedSongs.has(chant.id)) {
-      return false;
-    }
-  
+  const filteredChants = getSortedChants().filter(chant => {  
     // 팀 필터링
     if (exploreTeamFilter !== '전체' && chant.team !== exploreTeamFilter) {
       return false;
@@ -674,23 +644,6 @@ const getSortedChants = () => {
       <div className="flex items-center gap-3">
         <button
           onClick={() => {
-            setActiveTab('explore');
-            setShowPlayer(false);
-            setShowOnlyLiked(!showOnlyLiked);
-          }}
-          className={`relative rounded-full p-2 transition-all ${
-            showOnlyLiked ? 'bg-pink-100' : 'bg-gray-100 hover:bg-gray-200'
-          }`}
-        >
-          <Heart className={`w-5 h-5 ${showOnlyLiked ? 'text-pink-600' : 'text-gray-600'}`} />
-          {likedSongs.size > 0 && (
-            <span className="absolute -top-1 -right-1 bg-[#ff4757] text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium">
-              {likedSongs.size}
-            </span>
-          )}
-        </button>
-        <button
-          onClick={() => {
             const today = new Date();
             const yyyy = today.getFullYear();
             const mm = String(today.getMonth() + 1).padStart(2, '0');
@@ -828,7 +781,6 @@ const getSortedChants = () => {
                 currentPlayer={currentPlayer}
                 playerSongs={playerSongs}
                 selectedTeam={selectedTeam}
-                likedSongs={likedSongs}
                 fetchJsonData={fetchJsonData}
                 loading={loading}
                 error={error}
@@ -839,7 +791,6 @@ const getSortedChants = () => {
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}
                 handleShareLineup={handleShareLineup}
@@ -862,12 +813,7 @@ const getSortedChants = () => {
                 handleCompositionEnd={handleCompositionEnd}
                 exploreTeamFilter={exploreTeamFilter}
                 setExploreTeamFilter={setExploreTeamFilter}
-                sortBy={sortBy}
-                setSortBy={setSortBy}
                 playerSongs={playerSongs}
-                likedSongs={likedSongs}
-                showOnlyLiked={showOnlyLiked}
-                setShowOnlyLiked={setShowOnlyLiked}
                 filteredChants={filteredChants}
                 error={error}
                 setSelectedDate={setSelectedDate}
@@ -875,7 +821,6 @@ const getSortedChants = () => {
                 setCurrentPlayer={setCurrentPlayer}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
                 handleShare={handleShare}
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Play, Share2, Plus, Heart } from 'lucide-react';
+import { Play, Share2, Plus } from 'lucide-react';
 import { getTeamInfo, getPositionKorean } from '../utils/team';
 
 const ChantCard = ({
@@ -8,8 +8,6 @@ const ChantCard = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
-  likedSongs,
   handleShare
 }) => {
   const openPlayer = () => {
@@ -53,28 +51,8 @@ const ChantCard = ({
               </span>
             </>
           )}
-          <span className="text-gray-300 dark:text-gray-600">•</span>
-          <div className="flex items-center gap-1">
-            <Heart className="w-3 h-3 text-red-400" />
-            <span className="text-xs text-gray-500 dark:text-gray-400">{chant.likes.toLocaleString()}</span>
-          </div>
         </div>
       </div>
-      <button
-        onClick={e => {
-          e.stopPropagation();
-          toggleLike(chant.id);
-        }}
-        className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-      >
-        <Heart
-          className={`w-5 h-5 transition-all ${
-            likedSongs.has(chant.id)
-              ? 'text-red-500 fill-red-500 scale-110'
-              : 'text-gray-300 hover:text-red-400'
-          }`}
-        />
-      </button>
     </div>
 
     <div className="flex items-center gap-2">

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   Search,
   Filter,
-  Heart,
-  Circle,
   RefreshCw,
   AlertCircle,
 } from 'lucide-react';
@@ -15,12 +13,7 @@ const ExploreTab = ({
   handleCompositionEnd,
   exploreTeamFilter,
   setExploreTeamFilter,
-  sortBy,
-  setSortBy,
   playerSongs,
-  likedSongs,
-  showOnlyLiked,
-  setShowOnlyLiked,
   filteredChants,
   error,
   setSelectedDate,
@@ -28,7 +21,6 @@ const ExploreTab = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
   handleShare,
   setSearchQuery,
   isComposing,
@@ -69,43 +61,13 @@ const ExploreTab = ({
           <option value="KT">KT 위즈</option>
         </select>
       </div>
-      <div className="flex items-center gap-3 overflow-x-auto pb-3">
-        {[
-          { key: 'popular', label: '인기순', icon: Heart, color: 'from-red-500 to-pink-500' },
-          { key: 'name', label: '가나다순', icon: Circle, color: 'from-blue-500 to-indigo-500' },
-        ].map(({ key, label, icon: Icon, color }) => (
-          <button
-            key={key}
-            onClick={() => setSortBy(key)}
-            className={`flex items-center gap-2 px-5 py-3 rounded-full whitespace-nowrap transition-all font-medium ${
-              sortBy === key
-                ? `bg-gradient-to-r ${color} text-white shadow-lg shadow-gray-300 scale-105`
-                : 'bg-white text-gray-700 hover:bg-gray-50 border border-gray-200 hover:border-gray-300 hover:shadow-sm'
-            }`}
-          >
-            <Icon className="w-4 h-4" />
-            {label}
-          </button>
-        ))}
-      </div>
     </div>
     {/* 통계 카드 */}
-    <div className="grid grid-cols-3 gap-4 mb-6">
+    <div className="grid grid-cols-2 gap-4 mb-6">
       <div className="bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 rounded-2xl p-4 text-white shadow-lg">
         <h3 className="text-xl font-bold">{playerSongs.length}</h3>
         <p className="text-sm text-blue-100 mt-1">총 응원가</p>
       </div>
-      <button
-        onClick={() => setShowOnlyLiked(!showOnlyLiked)}
-        className={`bg-gradient-to-br rounded-2xl p-4 text-white transition-all transform duration-200 shadow-lg ${
-          showOnlyLiked
-            ? 'from-pink-500 via-pink-600 to-rose-600 scale-105 shadow-xl ring-2 ring-pink-200'
-            : 'from-purple-500 via-purple-600 to-purple-700 hover:scale-102 hover:shadow-xl'
-        }`}
-      >
-        <h3 className="text-xl font-bold">{likedSongs.size}</h3>
-        <p className="text-sm text-purple-100 mt-1">{showOnlyLiked ? '💖 선택됨' : '좋아한 곡'}</p>
-      </button>
       <div className="bg-gradient-to-br from-emerald-500 via-emerald-600 to-emerald-700 rounded-2xl p-4 text-white shadow-lg">
         <h3 className="text-xl font-bold">{filteredChants.length}</h3>
         <p className="text-sm text-emerald-100 mt-1">검색 결과</p>
@@ -115,9 +77,7 @@ const ExploreTab = ({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold">
-          {showOnlyLiked
-            ? '❤️ 좋아한 응원가'
-            : exploreTeamFilter === '전체'
+          {exploreTeamFilter === '전체'
             ? '전체 응원가'
             : `${exploreTeamFilter} 응원가`}
         </h2>
@@ -154,27 +114,18 @@ const ExploreTab = ({
           setCurrentPlayer={setCurrentPlayer}
           setPlaySource={setPlaySource}
           setShowPlayer={setShowPlayer}
-          toggleLike={toggleLike}
-          likedSongs={likedSongs}
           handleShare={handleShare}
         />
       ))}
-      {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체' || showOnlyLiked) && !isComposing && (
+      {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체') && !isComposing && (
         <div className="text-center py-8 text-gray-500">
           <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>
-            {showOnlyLiked
-              ? '좋아한 응원가가 없습니다'
-              : searchQuery
+            {searchQuery
               ? `"${searchQuery}"에 대한 검색 결과가 없습니다`
               : `${exploreTeamFilter} 팀의 응원가가 없습니다`}
           </p>
           <div className="flex gap-2 justify-center mt-2">
-            {showOnlyLiked && (
-              <button onClick={() => setShowOnlyLiked(false)} className="text-[#0ea5e9] text-sm">
-                전체 응원가 보기
-              </button>
-            )}
             {searchQuery && (
               <button onClick={() => setSearchQuery('')} className="text-[#0ea5e9] text-sm">
                 검색어 지우기

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -7,7 +7,6 @@ const LineupTab = ({
   currentPlayer,
   playerSongs,
   selectedTeam,
-  likedSongs,
   fetchJsonData,
   loading,
   error,
@@ -18,7 +17,6 @@ const LineupTab = ({
   setCurrentLineupIndex,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
   gameLineups,
   setSelectedDate,
   handleShareLineup,
@@ -97,8 +95,6 @@ const LineupTab = ({
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
-                likedSongs={likedSongs}
               />
             ))
           ) : (

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Play, Heart } from 'lucide-react';
+import { Play } from 'lucide-react';
 
 const PlayerCard = ({
   player,
@@ -10,9 +10,7 @@ const PlayerCard = ({
   setCurrentPlayer,
   setCurrentLineupIndex,
   setPlaySource,
-  setShowPlayer,
-  toggleLike,
-  likedSongs
+  setShowPlayer
 }) => {
   const openPlayer = () => {
     const globalIndex = playerSongs.findIndex(
@@ -61,18 +59,6 @@ const PlayerCard = ({
           className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
         >
           <Play className="w-4 h-4" />
-        </button>
-        <button
-          onClick={e => {
-            e.stopPropagation();
-            toggleLike(player.id);
-          }}
-        >
-          <Heart
-            className={`w-5 h-5 transition-colors ${
-              likedSongs.has(player.id) ? 'text-red-500 fill-red-500' : 'text-gray-300'
-            }`}
-          />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove `likedSongs` and `showOnlyLiked` handling from `App`
- simplify song sorting
- strip like-related UI from `ExploreTab`, `PlayerCard`, and `ChantCard`
- adjust `LineupTab` to match new `PlayerCard` props

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580d470ee4833184b13f8c0d3f81cb