### PR TITLE
Remove like UI from explore and lineup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ import {
   Circle,
   Music,
   Search,
-  Heart,
   Star,
   TrendingUp,
   Filter,
@@ -48,8 +47,6 @@ const debugLog = (...args) => {
 
 const JikgwanGaja = () => {
   
-  const [showOnlyLiked, setShowOnlyLiked] = useState(false);
-
   const [exploreTeamFilter, setExploreTeamFilter] = useState('전체');
 
   const [currentPlayer, setCurrentPlayer] = useState(0);
@@ -68,8 +65,6 @@ const JikgwanGaja = () => {
   });
 
   const [selectedTeam, setSelectedTeam] = useState('KIA');
-  const [sortBy, setSortBy] = useState('name');
-  const [likedSongs, setLikedSongs] = useState(new Set());
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
   
@@ -402,22 +397,6 @@ const JikgwanGaja = () => {
     return `${month}월 ${day}일(${dayName})`;
   };
 
-  const toggleLike = (songId) => {
-    debugLog('toggleLike 호출됨:', songId);
-    debugLog('현재 likedSongs:', likedSongs);
-    
-    const newLiked = new Set(likedSongs);
-    if (newLiked.has(songId)) {
-      newLiked.delete(songId);
-      debugLog('좋아요 제거:', songId);
-    } else {
-      newLiked.add(songId);
-      debugLog('좋아요 추가:', songId);
-    }
-    
-    debugLog('새로운 likedSongs:', newLiked);
-    setLikedSongs(newLiked);
-  };
 
 // getSortedChants 함수 수정 - 가나다순 정렬만 지원
 const getSortedChants = () => {
@@ -427,11 +406,6 @@ const getSortedChants = () => {
 };
 
   const filteredChants = getSortedChants().filter(chant => {
-    // 좋아한 곡만 보기 필터
-    if (showOnlyLiked && !likedSongs.has(chant.id)) {
-      return false;
-    }
-  
     // 팀 필터링
     if (exploreTeamFilter !== '전체' && chant.team !== exploreTeamFilter) {
       return false;
@@ -668,23 +642,6 @@ const getSortedChants = () => {
       <div className="flex items-center gap-3">
         <button
           onClick={() => {
-            setActiveTab('explore');
-            setShowPlayer(false);
-            setShowOnlyLiked(!showOnlyLiked);
-          }}
-          className={`relative rounded-full p-2 transition-all ${
-            showOnlyLiked ? 'bg-pink-100' : 'bg-gray-100 hover:bg-gray-200'
-          }`}
-        >
-          <Heart className={`w-5 h-5 ${showOnlyLiked ? 'text-pink-600' : 'text-gray-600'}`} />
-          {likedSongs.size > 0 && (
-            <span className="absolute -top-1 -right-1 bg-[#ff4757] text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium">
-              {likedSongs.size}
-            </span>
-          )}
-        </button>
-        <button
-          onClick={() => {
             const today = new Date();
             const yyyy = today.getFullYear();
             const mm = String(today.getMonth() + 1).padStart(2, '0');
@@ -823,7 +780,6 @@ const getSortedChants = () => {
                 playerSongs={playerSongs}
                 selectedTeam={selectedTeam}
                 selectedDate={selectedDate}
-                likedSongs={likedSongs}
                 fetchJsonData={fetchJsonData}
                 loading={loading}
                 error={error}
@@ -834,7 +790,6 @@ const getSortedChants = () => {
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}
                 handleShareLineup={handleShareLineup}
@@ -857,11 +812,7 @@ const getSortedChants = () => {
                 handleCompositionEnd={handleCompositionEnd}
                 exploreTeamFilter={exploreTeamFilter}
                 setExploreTeamFilter={setExploreTeamFilter}
-                setSortBy={setSortBy}
                 playerSongs={playerSongs}
-                likedSongs={likedSongs}
-                showOnlyLiked={showOnlyLiked}
-                setShowOnlyLiked={setShowOnlyLiked}
                 filteredChants={filteredChants}
                 error={error}
                 setSelectedDate={setSelectedDate}
@@ -869,7 +820,6 @@ const getSortedChants = () => {
                 setCurrentPlayer={setCurrentPlayer}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
                 handleShare={handleShare}
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Play, Share2, Plus, Heart } from 'lucide-react';
+import { Play, Share2, Plus } from 'lucide-react';
 import { getTeamInfo, getPositionKorean } from '../utils/team';
 
 const ChantCard = ({
@@ -8,8 +8,6 @@ const ChantCard = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
-  likedSongs,
   handleShare
 }) => {
   const openPlayer = () => {
@@ -55,21 +53,7 @@ const ChantCard = ({
           )}
         </div>
       </div>
-      <button
-        onClick={e => {
-          e.stopPropagation();
-          toggleLike(chant.id);
-        }}
-        className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-      >
-        <Heart
-          className={`w-5 h-5 transition-all ${
-            likedSongs.has(chant.id)
-              ? 'text-red-500 fill-red-500 scale-110'
-              : 'text-gray-300 hover:text-red-400'
-          }`}
-        />
-      </button>
+
     </div>
 
     <div className="flex items-center gap-2">

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -16,9 +16,6 @@ const ExploreTab = ({
   setExploreTeamFilter,
   setSortBy,
   playerSongs,
-  likedSongs,
-  showOnlyLiked,
-  setShowOnlyLiked,
   filteredChants,
   error,
   setSelectedDate,
@@ -26,7 +23,6 @@ const ExploreTab = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
   handleShare,
   setSearchQuery,
   isComposing,
@@ -83,17 +79,6 @@ const ExploreTab = ({
         <h3 className="text-xl font-bold">{playerSongs.length}</h3>
         <p className="text-sm text-blue-100 mt-1">총 응원가</p>
       </div>
-      <button
-        onClick={() => setShowOnlyLiked(!showOnlyLiked)}
-        className={`bg-gradient-to-br rounded-2xl p-4 text-white transition-all transform duration-200 shadow-lg ${
-          showOnlyLiked
-            ? 'from-pink-500 via-pink-600 to-rose-600 scale-105 shadow-xl ring-2 ring-pink-200'
-            : 'from-purple-500 via-purple-600 to-purple-700 hover:scale-102 hover:shadow-xl'
-        }`}
-      >
-        <h3 className="text-xl font-bold">{likedSongs.size}</h3>
-        <p className="text-sm text-purple-100 mt-1">{showOnlyLiked ? '💖 선택됨' : '좋아한 곡'}</p>
-      </button>
       <div className="bg-gradient-to-br from-emerald-500 via-emerald-600 to-emerald-700 rounded-2xl p-4 text-white shadow-lg">
         <h3 className="text-xl font-bold">{filteredChants.length}</h3>
         <p className="text-sm text-emerald-100 mt-1">검색 결과</p>
@@ -103,9 +88,7 @@ const ExploreTab = ({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold">
-          {showOnlyLiked
-            ? '❤️ 좋아한 응원가'
-            : exploreTeamFilter === '전체'
+          {exploreTeamFilter === '전체'
             ? '전체 응원가'
             : `${exploreTeamFilter} 응원가`}
         </h2>
@@ -142,27 +125,18 @@ const ExploreTab = ({
           setCurrentPlayer={setCurrentPlayer}
           setPlaySource={setPlaySource}
           setShowPlayer={setShowPlayer}
-          toggleLike={toggleLike}
-          likedSongs={likedSongs}
           handleShare={handleShare}
         />
       ))}
-      {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체' || showOnlyLiked) && !isComposing && (
+      {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체') && !isComposing && (
         <div className="text-center py-8 text-gray-500">
           <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>
-            {showOnlyLiked
-              ? '좋아한 응원가가 없습니다'
-              : searchQuery
+            {searchQuery
               ? `"${searchQuery}"에 대한 검색 결과가 없습니다`
               : `${exploreTeamFilter} 팀의 응원가가 없습니다`}
           </p>
           <div className="flex gap-2 justify-center mt-2">
-            {showOnlyLiked && (
-              <button onClick={() => setShowOnlyLiked(false)} className="text-[#0ea5e9] text-sm">
-                전체 응원가 보기
-              </button>
-            )}
             {searchQuery && (
               <button onClick={() => setSearchQuery('')} className="text-[#0ea5e9] text-sm">
                 검색어 지우기

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -8,7 +8,6 @@ const LineupTab = ({
   playerSongs,
   selectedTeam,
   selectedDate,
-  likedSongs,
   fetchJsonData,
   loading,
   error,
@@ -19,7 +18,6 @@ const LineupTab = ({
   setCurrentLineupIndex,
   setPlaySource,
   setShowPlayer,
-  toggleLike,
   gameLineups,
   setSelectedDate,
   handleShareLineup,
@@ -95,8 +93,6 @@ const LineupTab = ({
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
-                toggleLike={toggleLike}
-                likedSongs={likedSongs}
               />
             ))
           ) : (

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Play, Heart } from 'lucide-react';
+import { Play } from 'lucide-react';
 
 const PlayerCard = ({
   player,
@@ -10,9 +10,7 @@ const PlayerCard = ({
   setCurrentPlayer,
   setCurrentLineupIndex,
   setPlaySource,
-  setShowPlayer,
-  toggleLike,
-  likedSongs
+  setShowPlayer
 }) => {
   const openPlayer = () => {
     const globalIndex = playerSongs.findIndex(
@@ -61,18 +59,6 @@ const PlayerCard = ({
           className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
         >
           <Play className="w-4 h-4" />
-        </button>
-        <button
-          onClick={e => {
-            e.stopPropagation();
-            toggleLike(player.id);
-          }}
-        >
-          <Heart
-            className={`w-5 h-5 transition-colors ${
-              likedSongs.has(player.id) ? 'text-red-500 fill-red-500' : 'text-gray-300'
-            }`}
-          />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- drop like song feature from App
- simplify song sort and search filter
- clean up ExploreTab, LineupTab, ChantCard, and PlayerCard

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580fd96c78833190f292e042911b3f