### PR TITLE
Update crawler start URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The crawler saves each game's lineup JSON files and then rebuilds the index auto
 ## Crawling player info
 
 `public/kbo_players_crawler.py` scrapes basic player details from the KBO web site.
-It requires Selenium with Chrome and writes the results to `public/data/kboPlayers.json`.
+It starts at [https://www.koreabaseball.com/Player/Search.aspx](https://www.koreabaseball.com/Player/Search.aspx)
+and iterates through each team. The script requires Selenium with Chrome and writes
+the results to `public/data/kboPlayers.json`.
 The crawler records each player's school instead of the `updatedAt` timestamp found in
 older data files.
 

--- a/public/kbo_players_crawler.py
+++ b/public/kbo_players_crawler.py
@@ -91,7 +91,8 @@ def crawl_players() -> list:
     driver = webdriver.Chrome(
         service=Service(ChromeDriverManager().install()), options=options
     )
-    driver.get("https://www.koreabaseball.com/Record/Player/Basic/PlayerBasic.aspx")
+    # Start from the player search page which lists all players by team
+    driver.get("https://www.koreabaseball.com/Player/Search.aspx")
     time.sleep(2)
 
     all_players = []


### PR DESCRIPTION
## Summary
- update player crawler to start from the KBO player search page
- document the new starting URL in the README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685817090980833191e736684d6a7726