### PR TITLE
Split lineup and player crawlers

### DIFF
--- a/.github/workflows/lineup-crawl.yml
+++ b/.github/workflows/lineup-crawl.yml
@@ -1,4 +1,4 @@
-name: Daily KBO crawl
+name: Daily KBO lineup crawl
 
 on:
   schedule:
@@ -71,10 +71,6 @@ jobs:
             fi
           done
 
-      - name: Run player crawler
-        run: |
-          export DISPLAY=:99
-          python public/kbo_players_crawler.py
 
       - name: Rebuild lineup index
         run: npm run build-lineup-index
@@ -83,7 +79,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add public/data/kbo_crawler_data public/data/kboPlayers.json
+          git add public/data/kbo_crawler_data
           git commit -m "Daily data update" || echo "No changes to commit"
           git pull --rebase origin main
           git push origin main

--- a/.github/workflows/player-crawl.yml
+++ b/.github/workflows/player-crawl.yml
@@ -1,0 +1,50 @@
+name: Daily KBO player crawl
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests beautifulsoup4 pandas selenium webdriver-manager
+
+      - name: Install Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+
+      - name: Run player crawler
+        run: |
+          export DISPLAY=:99
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          python public/kbo_players_crawler.py
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/kboPlayers.json
+          git commit -m "Daily player update" || echo "No changes to commit"
+          git pull --rebase origin main
+          git push origin main

--- a/.github/workflows/rebuild-index.yml
+++ b/.github/workflows/rebuild-index.yml
@@ -3,7 +3,7 @@ name: Manual lineup index rebuild
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["Daily KBO crawl"]
+    workflows: ["Daily KBO lineup crawl"]
     types:
       - completed
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ python public/kbo_players_crawler.py
 
 ## Automated daily crawl
 
-The GitHub Actions workflow at `.github/workflows/daily-crawl.yml` runs every
-day to fetch new lineups **and** the full player list. The workflow rebuilds
-`public/data/kbo_crawler_data/index.json` and updates
-`public/data/kboPlayers.json`, committing any changes back to the repository
-automatically.
+Two GitHub Actions workflows keep the data updated:
+
+- `.github/workflows/lineup-crawl.yml` fetches new lineups several times each day and rebuilds `public/data/kbo_crawler_data/index.json`.
+- `.github/workflows/player-crawl.yml` updates `public/data/kboPlayers.json` daily at 00:00 UTC.
+
+Both workflows commit any changes back to the repository automatically.
 
 ## Basic npm commands
 


### PR DESCRIPTION
## Summary
- run lineups and players crawlers via separate workflows
- call the new lineup workflow from the index rebuild job
- update README with the new workflow names

## Testing
- `CI=true npm test` *(fails: react-scripts missing)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685818bfe0688331993ac7999d7722e6