### PR TITLE
Improve dark mode styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -639,8 +639,8 @@ const getSortedChants = () => {
         </div>
                           
         <div>
-          <h1 className="text-xl font-bold text-gray-900">직관가자</h1>
-          <p className="text-sm text-gray-500">
+          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">직관가자</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-300">
             {getTeamInfo(selectedTeam).fullName} • {formatDateKorean(selectedDate)}
           </p>
         </div>
@@ -756,12 +756,12 @@ const getSortedChants = () => {
       <div className="p-4">
         {showPlayer ? (
           <div className="space-y-4">
-            <button 
+            <button
               onClick={() => setShowPlayer(false)}
-            className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 transition-colors"
+              className="flex items-center text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 transition-colors"
             >
               <SkipBack className="w-5 h-5" />
-              라인업으로 돌아가기
+              <span className="sr-only">라인업으로 돌아가기</span>
             </button>
             <PlayerTab
               playerSongs={playerSongs}

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -63,7 +63,7 @@ const ExploreTab = ({
           <span className="text-sm text-gray-700">팀 선택</span>
           <button
             onClick={() => setExploreTeamFilter('전체')}
-            className={`bg-white border px-3 py-1 rounded-lg text-xs font-medium ${
+            className={`bg-white border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 ${
               exploreTeamFilter === '전체'
                 ? 'ring-2 ring-blue-500 border-transparent'
                 : 'border-gray-200'
@@ -88,7 +88,7 @@ const ExploreTab = ({
                 alt={team}
                 className="w-8 h-8 object-contain mb-1"
               />
-              <span className="text-xs">{team}</span>
+              <span className="text-xs text-gray-900">{team}</span>
             </button>
           ))}
         </div>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -27,7 +27,7 @@ const LineupTab = ({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-gray-800">오늘의 라인업</h2>
+        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">오늘의 라인업</h2>
         <div className="flex items-center gap-2">
           <button
             onClick={handleShareLineup}


### PR DESCRIPTION
## Summary
- adjust `오늘의 라인업` heading color in dark mode
- keep header text visible in dark mode
- ensure team names are readable in the Explore view
- show only a back arrow for the player screen

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685820b05ba0833197f0dbdb60a8019f