### PR TITLE
Add URL sync for selected player

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,8 @@ const JikgwanGaja = () => {
   const [currentPlayer, setCurrentPlayer] = useState(0);
   const [activeTab, setActiveTab] = useState('lineup');
   const [showPlayer, setShowPlayer] = useState(false);
+  const [currentPlayerName, setCurrentPlayerName] = useState('');
+  const [pendingPlayerName, setPendingPlayerName] = useState('');
   const [isDarkMode, setIsDarkMode] = useState(() => {
     const stored = localStorage.getItem('theme');
     if (stored) return stored === 'dark';
@@ -79,8 +81,10 @@ const JikgwanGaja = () => {
     const params = new URLSearchParams(window.location.search);
     const teamParam = params.get('team');
     const dateParam = params.get('date');
+    const playerParam = params.get('player');
     if (teamParam) setSelectedTeam(teamParam);
     if (dateParam) setSelectedDate(dateParam);
+    if (playerParam) setPendingPlayerName(playerParam);
 
     const setTabFromHash = () => {
       const tab = window.location.hash.replace('#', '');
@@ -99,13 +103,18 @@ const JikgwanGaja = () => {
     const params = new URLSearchParams(window.location.search);
     params.set('team', selectedTeam);
     params.set('date', selectedDate);
+    if (showPlayer && currentPlayerName) {
+      params.set('player', currentPlayerName);
+    } else {
+      params.delete('player');
+    }
     const query = params.toString();
     window.history.replaceState(
       null,
       '',
       `${window.location.pathname}?${query}#${activeTab}`
     );
-  }, [selectedTeam, selectedDate, activeTab]);
+  }, [selectedTeam, selectedDate, activeTab, showPlayer, currentPlayerName]);
 
   useEffect(() => {
     if (isDarkMode) {
@@ -156,6 +165,22 @@ const JikgwanGaja = () => {
     fetchJsonData,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
+
+  useEffect(() => {
+    if (pendingPlayerName && playerSongs.length > 0) {
+      const idx = playerSongs.findIndex(
+        (song) =>
+          song.playerName === pendingPlayerName && song.team === selectedTeam
+      );
+      if (idx !== -1) {
+        setCurrentPlayer(idx);
+        setCurrentPlayerName(pendingPlayerName);
+        setPlaySource('explore');
+        setShowPlayer(true);
+      }
+      setPendingPlayerName('');
+    }
+  }, [pendingPlayerName, playerSongs, selectedTeam]);
 
   useEffect(() => {
     if (gameLineups.length > 0 && playerSongs.length > 0) {
@@ -794,6 +819,7 @@ const getSortedChants = () => {
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
+                setCurrentPlayerName={setCurrentPlayerName}
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}
                 handleShareLineup={handleShareLineup}
@@ -827,6 +853,7 @@ const getSortedChants = () => {
                 handleShare={handleShare}
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}
+                setCurrentPlayerName={setCurrentPlayerName}
               />
             )}
           </>

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -8,13 +8,15 @@ const ChantCard = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  handleShare
+  handleShare,
+  setCurrentPlayerName
 }) => {
   const openPlayer = () => {
     const playerIndex = playerSongs.findIndex(c => c.id === chant.id);
     if (playerIndex !== -1) {
       setCurrentPlayer(playerIndex);
       setPlaySource('explore');
+      setCurrentPlayerName(chant.playerName);
       setShowPlayer(true);
     }
   };

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -27,6 +27,7 @@ const ExploreTab = ({
   handleShare,
   setSearchQuery,
   isComposing,
+  setCurrentPlayerName,
 }) => {
   const teamOptions = [
     'KIA',
@@ -156,6 +157,7 @@ const ExploreTab = ({
           setPlaySource={setPlaySource}
           setShowPlayer={setShowPlayer}
           handleShare={handleShare}
+          setCurrentPlayerName={setCurrentPlayerName}
         />
       ))}
       {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체') && !isComposing && (

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -18,6 +18,7 @@ const LineupTab = ({
   setCurrentLineupIndex,
   setPlaySource,
   setShowPlayer,
+  setCurrentPlayerName,
   gameLineups,
   setSelectedDate,
   handleShareLineup,
@@ -93,6 +94,7 @@ const LineupTab = ({
                 setCurrentLineupIndex={setCurrentLineupIndex}
                 setPlaySource={setPlaySource}
                 setShowPlayer={setShowPlayer}
+                setCurrentPlayerName={setCurrentPlayerName}
               />
             ))
           ) : (

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -10,7 +10,8 @@ const PlayerCard = ({
   setCurrentPlayer,
   setCurrentLineupIndex,
   setPlaySource,
-  setShowPlayer
+  setShowPlayer,
+  setCurrentPlayerName
 }) => {
   const openPlayer = () => {
     const globalIndex = playerSongs.findIndex(
@@ -26,6 +27,7 @@ const PlayerCard = ({
 
     setCurrentLineupIndex(index);
     setPlaySource('lineup');
+    setCurrentPlayerName(player.playerName);
     setShowPlayer(true);
   };
 


### PR DESCRIPTION
## Summary
- sync selected player with query string
- record pending player from URL on initial load
- open player when dataset is ready
- pass `setCurrentPlayerName` prop to lineup and explore components
- update player and chant card handlers to set player name

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685822c1b4848331bc999453f201819b