### PR TITLE
Fix YouTube cropping on mobile

### DIFF
--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -41,7 +41,7 @@ const PlayerTab = ({
   const getDisplayPosition = () => currentChant.position;
   const opts = {
     width: '100%',
-    height: '235',
+    height: '100%',
     playerVars: {
       autoplay: 1,
       mute: 0,

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -22,7 +22,7 @@ const TeamChantsTab = ({
 
   const opts = {
     width: '100%',
-    height: '200',
+    height: '100%',
     playerVars: {
       autoplay: 0,
       mute: 0,


### PR DESCRIPTION
## Summary
- set embedded YouTube video height to `100%`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685824cd4ee48331b8b7b71044346f01