### PR TITLE
Fix explore filter to sync with selected team

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,6 +68,11 @@ const JikgwanGaja = () => {
   const [selectedTeam, setSelectedTeam] = useState('KIA');
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
+
+  // Ensure explore tab reflects the globally selected team
+  useEffect(() => {
+    setExploreTeamFilter(selectedTeam);
+  }, [selectedTeam]);
   
 
   const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
## Summary
- ensure the Explore tab updates its team filter whenever the global team changes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685882f1a1388331b840f5784c24c972