### PR TITLE
Implement local logging for request button

### DIFF
--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import YouTube from 'react-youtube';
 import { Music, SkipBack, SkipForward, Share2, Plus, Mail } from 'lucide-react';
 import { getTeamInfo, getPositionKorean, getBattingOrder } from '../utils/team';
+import { logRequest } from '../utils/logging';
 import LyricsSection from './LyricsSection';
 const PlayerTab = ({
   playerSongs,
@@ -50,19 +51,13 @@ const PlayerTab = ({
     },
   };
   const handleInfoRequest = () => {
-    const subject = encodeURIComponent('선수 정보 요청');
-    const body = encodeURIComponent(
-      `${currentChant.playerName} (${getDisplayTeam()}) 정보 요청`
-    );
-    window.location.href = `mailto:ltnalsxl1011@gmail.com?subject=${subject}&body=${body}`;
+    logRequest(currentChant.playerName, 'info');
+    alert(`${currentChant.playerName} 선수에 대한 요청이 완료되었습니다.`);
   };
 
   const handleSongRequest = () => {
-    const subject = encodeURIComponent('응원가 요청');
-    const body = encodeURIComponent(
-      `${currentChant.playerName} (${getDisplayTeam()}) 응원가 요청`
-    );
-    window.location.href = `mailto:ltnalsxl1011@gmail.com?subject=${subject}&body=${body}`;
+    logRequest(currentChant.playerName, 'song');
+    alert(`${currentChant.playerName} 선수에 대한 요청이 완료되었습니다.`);
   };
   return (
     <div className="space-y-6">

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,9 @@
+export const logRequest = (playerName, type) => {
+  try {
+    const logs = JSON.parse(localStorage.getItem('requestLogs')) || [];
+    logs.push({ playerName, type, timestamp: new Date().toISOString() });
+    localStorage.setItem('requestLogs', JSON.stringify(logs));
+  } catch (err) {
+    console.error('Failed to log request', err);
+  }
+};


### PR DESCRIPTION
## Summary
- add a simple logging util that records requests to `localStorage`
- stop opening an email client when requesting info or chants
- show an alert when the request is logged

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859498a91b0833192ccd94e34ae71ed