### PR TITLE
Add player and chant statistics to Explore tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -166,6 +166,7 @@ const JikgwanGaja = () => {
     gameLineups,
     teamChants,
     kboPlayers,
+    rawSongs,
     loading,
     error,
     fetchJsonData,
@@ -849,6 +850,8 @@ const getSortedChants = () => {
                 exploreTeamFilter={exploreTeamFilter}
                 setExploreTeamFilter={setExploreTeamFilter}
                 playerSongs={playerSongs}
+                kboPlayers={kboPlayers}
+                rawSongs={rawSongs}
                 filteredChants={filteredChants}
                 error={error}
                 setSelectedDate={setSelectedDate}

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -17,6 +17,8 @@ const ExploreTab = ({
   setExploreTeamFilter,
   setSortBy,
   playerSongs,
+  kboPlayers,
+  rawSongs,
   filteredChants,
   error,
   setSelectedDate,
@@ -41,6 +43,10 @@ const ExploreTab = ({
     'NC',
     'KT',
   ];
+  const totalPlayers = Array.isArray(kboPlayers) ? kboPlayers.length : 0;
+  const totalChants = Array.isArray(rawSongs)
+    ? rawSongs.filter((song) => song.type === '응원가').length
+    : 0;
   return (
     <div className="space-y-4">
     {/* 검색 및 필터 */}
@@ -105,9 +111,13 @@ const ExploreTab = ({
       </div>
     </div>
     {/* 통계 카드 */}
-    <div className="grid grid-cols-2 gap-3 mb-4">
+    <div className="grid grid-cols-3 gap-3 mb-4">
+      <div className="bg-gradient-to-br from-indigo-500 via-indigo-600 to-indigo-700 rounded-xl p-3 text-white shadow">
+        <h3 className="text-lg font-bold">{totalPlayers}</h3>
+        <p className="text-xs text-indigo-100 mt-1">총 선수</p>
+      </div>
       <div className="bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 rounded-xl p-3 text-white shadow">
-        <h3 className="text-lg font-bold">{playerSongs.length}</h3>
+        <h3 className="text-lg font-bold">{totalChants}</h3>
         <p className="text-xs text-blue-100 mt-1">총 응원가</p>
       </div>
       <div className="bg-gradient-to-br from-emerald-500 via-emerald-600 to-emerald-700 rounded-xl p-3 text-white shadow">

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -94,6 +94,7 @@ const useKboData = () => {
   const [gameLineups, setGameLineups] = useState([]);
   const [teamChants, setTeamChants] = useState([]);
   const [kboPlayers, setKboPlayers] = useState([]);
+  const [rawSongs, setRawSongs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -120,6 +121,7 @@ const useKboData = () => {
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
       setKboPlayers(parsedKboPlayers);
+      setRawSongs(Array.isArray(songsData) ? songsData : []);
 
       // 선수 응원가 데이터 처리 - KBO 선수 기준으로 구성
       const parsedSongsRaw = parsedKboPlayers.map((player) => {
@@ -318,6 +320,7 @@ const useKboData = () => {
     gameLineups,
     teamChants,
     kboPlayers,
+    rawSongs,
     loading,
     error,
     fetchJsonData,


### PR DESCRIPTION
## Summary
- expose raw song data from `useKboData`
- pass `kboPlayers` and raw songs to `ExploreTab`
- show total players, total chants, and search results

## Testing
- `npm test --silent` *(fails: react-scripts not found / network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68582ef21f5483318a847f9bd52ed2c1