### PR TITLE
Add checkbox to filter players with songs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ const debugLog = (...args) => {
 const JikgwanGaja = () => {
   
   const [exploreTeamFilter, setExploreTeamFilter] = useState('전체');
+  const [hasSongOnly, setHasSongOnly] = useState(false);
 
   const [currentPlayer, setCurrentPlayer] = useState(0);
   const [activeTab, setActiveTab] = useState('lineup');
@@ -452,7 +453,11 @@ const getSortedChants = () => {
     if (exploreTeamFilter !== '전체' && chant.team !== exploreTeamFilter) {
       return false;
     }
-  
+
+    if (hasSongOnly && !chant.youtubeId) {
+      return false;
+    }
+
     // 검색어 필터링 (한국어 개선)
     if (!immediateSearch) return true;
     
@@ -849,6 +854,8 @@ const getSortedChants = () => {
                 handleCompositionEnd={handleCompositionEnd}
                 exploreTeamFilter={exploreTeamFilter}
                 setExploreTeamFilter={setExploreTeamFilter}
+                hasSongOnly={hasSongOnly}
+                setHasSongOnly={setHasSongOnly}
                 playerSongs={playerSongs}
                 kboPlayers={kboPlayers}
                 rawSongs={rawSongs}

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -16,6 +16,8 @@ const ExploreTab = ({
   exploreTeamFilter,
   setExploreTeamFilter,
   setSortBy,
+  hasSongOnly,
+  setHasSongOnly,
   playerSongs,
   kboPlayers,
   rawSongs,
@@ -108,6 +110,18 @@ const ExploreTab = ({
           <Circle className="w-4 h-4" />
           가나다순
         </button>
+        <div className="flex items-center gap-2">
+          <input
+            id="songOnly"
+            type="checkbox"
+            checked={hasSongOnly}
+            onChange={(e) => setHasSongOnly(e.target.checked)}
+            className="w-4 h-4 text-blue-600 border-gray-300 rounded"
+          />
+          <label htmlFor="songOnly" className="text-sm text-gray-700 whitespace-nowrap">
+            응원가 있는 선수만
+          </label>
+        </div>
       </div>
     </div>
     {/* 통계 카드 */}


### PR DESCRIPTION
## Summary
- allow filtering player list in Explore tab to only show players with cheer songs
- add checkbox UI and state handling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859508d4b6883318daa3f195059b444