### PR TITLE
Add 18:00 and 18:30 lineup crawl schedules

### DIFF
--- a/.github/workflows/lineup-crawl.yml
+++ b/.github/workflows/lineup-crawl.yml
@@ -11,6 +11,8 @@ on:
     - cron: '10 8 * * 1-5'  # 17:10 KST (평일)
     - cron: '30 8 * * *'  # 17:30 KST
     - cron: '40 6 * * 0,6'  # 15:40 KST (주말)
+    - cron: '0 9 * * *'   # 18:00 KST
+    - cron: '30 9 * * *'  # 18:30 KST
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- extend lineup crawler cron schedule to run later in the evening

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c226e6c3083318e0f88394b31f76e