### PR TITLE
Enable auto deploy after data updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: ["Manual lineup index rebuild"]
+    types:
+      - completed
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Two GitHub Actions workflows keep the data updated:
 
 Both workflows commit any changes back to the repository automatically.
 
+Any push to the `main` branch – including updates from these workflows –
+automatically triggers `.github/workflows/deploy.yml` to build the app and
+deploy it to Firebase.
+
 ## Basic npm commands
 
 ```bash


### PR DESCRIPTION
## Summary
- trigger `deploy.yml` when lineup index rebuild completes
- document auto deploy in README

## Testing
- `npm test` *(fails: `react-scripts` not found)*
- `npm install` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685c22a934dc83318e7b2a517e7d0680