### PR TITLE
Add sticky wrapper for mobile play all button

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -73,12 +73,14 @@ const LineupTab = ({
                   {currentGame.gameStatus && ` • ${currentGame.gameStatus}`}
                 </p>
               </div>
-              <button
-                onClick={handlePlayAll}
-                className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors"
-              >
-                전체 재생
-              </button>
+              <div className="sticky bottom-0 z-10 w-full md:w-auto md:static md:p-0 p-2 bg-white md:bg-transparent">
+                <button
+                  onClick={handlePlayAll}
+                  className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors"
+                >
+                  전체 재생
+                </button>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- keep the '전체 재생' button styles but wrap with a sticky container

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf47562488331b549dc1ed79b6738