### PR TITLE
Add calendar and team dropdowns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import YouTube from 'react-youtube';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
   SkipForward,
   SkipBack,
@@ -29,6 +29,8 @@ import { getTeamInfo, getPositionKorean, getBattingOrder } from './utils/team';
 import PlayerTab from './components/PlayerTab';
 import ExploreTab from './components/ExploreTab';
 import TeamChantsTab from './components/TeamChantsTab';
+import CalendarDropdown from './components/CalendarDropdown';
+import TeamDropdown from './components/TeamDropdown';
 import useKboData from './hooks/useKboData';
 
 // simple helper to avoid logs in production
@@ -173,6 +175,18 @@ const JikgwanGaja = () => {
     fetchJsonData,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
+  const gameDatesForTeam = useMemo(
+    () =>
+      new Set(
+        gameLineups
+          .filter((game) => {
+            const parts = game.id.split('_');
+            return parts.length === 2 && parts[1] === selectedTeam;
+          })
+          .map((game) => game.id.split('_')[0])
+      ),
+    [gameLineups, selectedTeam]
+  );
 
   useEffect(() => {
     if (pendingPlayerName && playerSongs.length > 0) {
@@ -609,61 +623,6 @@ const getSortedChants = () => {
 
 
 
-  // 날짜 옵션 생성 함수 - 경기가 없는 날도 포함
-  const getDateOptions = () => {
-    const today = new Date();
-    const yyyy = today.getFullYear();
-    const mm = String(today.getMonth() + 1).padStart(2, '0');
-    const dd = String(today.getDate()).padStart(2, '0');
-    const todayStr = `${yyyy}-${mm}-${dd}`;
-
-    debugLog('getDateOptions - selectedTeam:', selectedTeam);
-    debugLog('getDateOptions - gameLineups.length:', gameLineups.length);
-
-    // 해당 팀 경기 날짜 세트
-    const gameDates = new Set(
-      gameLineups
-        .filter(game => {
-          const idParts = game.id.split('_');
-          const isValidGame = idParts.length === 2 && idParts[1] === selectedTeam;
-          if (!isValidGame) {
-            debugLog('getDateOptions - Filtering out game:', game.id, 'for team:', selectedTeam);
-          }
-          return isValidGame;
-        })
-        .map(game => game.id.split('_')[0])
-    );
-
-    debugLog('getDateOptions - extracted gameDates:', Array.from(gameDates));
-
-    const allGameDates = Array.from(
-      new Set(gameLineups.map(game => game.id.split('_')[0]))
-    ).sort();
-
-    if (allGameDates.length === 0) {
-      return [{ value: todayStr, label: `${today.getMonth() + 1}월 ${today.getDate()}일 (${['일','월','화','수','목','금','토'][today.getDay()]})` }];
-    }
-
-    const startDate = new Date(allGameDates[0]);
-    const lastDateStr = allGameDates[allGameDates.length - 1];
-    const endDate = new Date(lastDateStr < todayStr ? todayStr : lastDateStr);
-
-    const options = [];
-    for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-      const year = d.getFullYear();
-      const month = d.getMonth() + 1;
-      const day = d.getDate();
-      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-      const dayName = ['일','월','화','수','목','금','토'][d.getDay()];
-      const hasGame = gameDates.has(dateStr);
-      options.push({
-        value: dateStr,
-        label: `${hasGame ? '⚾ ' : ''}${month}월 ${day}일 (${dayName})`
-      });
-    }
-
-    return options;
-  };
 
  return (
   <div className="max-w-md mx-auto bg-white min-h-screen dark:bg-gray-900 dark:text-gray-100">
@@ -732,34 +691,12 @@ const getSortedChants = () => {
 
        {/* 날짜/팀 선택 */}
         <div className="mt-4 flex items-center gap-3">
-          <select
+          <CalendarDropdown
             value={selectedDate}
-            onChange={(e) => setSelectedDate(e.target.value)}
-            className="bg-gray-50 text-gray-900 dark:bg-gray-700 dark:text-gray-100 text-sm rounded-lg px-4 py-2 border border-gray-200 dark:border-gray-600 focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent"
-          >
-            {getDateOptions().map(({ value, label }) => (
-              <option key={value} value={value} className="text-gray-900">
-                {label}
-              </option>
-            ))}
-          </select>
-          
-          <select
-            value={selectedTeam}
-            onChange={(e) => setSelectedTeam(e.target.value)}
-            className="bg-gray-50 text-gray-900 dark:bg-gray-700 dark:text-gray-100 text-sm rounded-lg px-4 py-2 border border-gray-200 dark:border-gray-600 focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent"
-          >
-            <option value="KIA" className="text-gray-900">KIA 타이거즈</option>
-            <option value="두산" className="text-gray-900">두산 베어스</option>
-            <option value="LG" className="text-gray-900">LG 트윈스</option>
-            <option value="삼성" className="text-gray-900">삼성 라이온즈</option>
-            <option value="롯데" className="text-gray-900">롯데 자이언츠</option>
-            <option value="SSG" className="text-gray-900">SSG 랜더스</option>
-            <option value="키움" className="text-gray-900">키움 히어로즈</option>
-            <option value="한화" className="text-gray-900">한화 이글스</option>
-            <option value="NC" className="text-gray-900">NC 다이노스</option>
-            <option value="KT" className="text-gray-900">KT 위즈</option>
-          </select>
+            onChange={setSelectedDate}
+            gameDates={gameDatesForTeam}
+          />
+          <TeamDropdown value={selectedTeam} onChange={setSelectedTeam} />
         </div>
      </div>
 

--- a/src/components/CalendarDropdown.jsx
+++ b/src/components/CalendarDropdown.jsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
+
+const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+const CalendarDropdown = ({ value, onChange, gameDates }) => {
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState(() => new Date(value));
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  useEffect(() => {
+    setCurrent(new Date(value));
+  }, [value]);
+
+  const formatDate = (d) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${dd}`;
+  };
+
+  const formatLabel = (d) => {
+    const m = d.getMonth() + 1;
+    const dd = d.getDate();
+    const name = dayNames[d.getDay()];
+    return `${m}월 ${dd}일 (${name})`;
+  };
+
+  const prevMonth = () => {
+    setCurrent(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  };
+  const nextMonth = () => {
+    setCurrent(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+  };
+
+  const monthStart = new Date(current.getFullYear(), current.getMonth(), 1);
+  const monthEnd = new Date(current.getFullYear(), current.getMonth() + 1, 0);
+  const startDay = monthStart.getDay();
+  const daysInMonth = monthEnd.getDate();
+
+  const cells = [];
+  for (let i = 0; i < startDay; i++) {
+    cells.push(null);
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push(new Date(current.getFullYear(), current.getMonth(), d));
+  }
+
+  const isSameDay = (a, b) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm rounded-xl px-4 py-2 border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-600"
+      >
+        {formatLabel(new Date(value))}
+        <ChevronDown className="w-4 h-4 ml-2" />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-4">
+          <div className="flex items-center justify-between mb-2">
+            <button onClick={prevMonth} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded">
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-sm font-medium">
+              {current.getFullYear()}년 {current.getMonth() + 1}월
+            </span>
+            <button onClick={nextMonth} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded">
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+          <div className="grid grid-cols-7 gap-1 text-xs text-center mb-1">
+            {dayNames.map((d) => (
+              <div key={d} className="font-medium">
+                {d}
+              </div>
+            ))}
+            {cells.map((date, idx) => {
+              if (!date) return <div key={idx} />;
+              const formatted = formatDate(date);
+              const hasGame = gameDates?.has(formatted);
+              const selected = value && isSameDay(date, new Date(value));
+              return (
+                <button
+                  key={idx}
+                  onClick={() => {
+                    onChange(formatted);
+                    setOpen(false);
+                  }}
+                  className={`w-8 h-8 flex items-center justify-center rounded-full transition-colors ${
+                    selected
+                      ? 'bg-blue-500 text-white'
+                      : hasGame
+                      ? 'bg-blue-100 dark:bg-blue-900'
+                      : ''
+                  } hover:bg-blue-200 dark:hover:bg-blue-700`}
+                >
+                  {date.getDate()}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendarDropdown;

--- a/src/components/TeamDropdown.jsx
+++ b/src/components/TeamDropdown.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { getTeamInfo } from '../utils/team';
+
+const teams = ['KIA','두산','LG','삼성','롯데','SSG','키움','한화','NC','KT'];
+
+const TeamDropdown = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm rounded-xl px-4 py-2 border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-600"
+      >
+        {getTeamInfo(value).fullName}
+        <ChevronDown className="w-4 h-4 ml-2" />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 w-40 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl py-1 text-sm">
+          {teams.map(team => (
+            <button
+              key={team}
+              onClick={() => {
+                onChange(team);
+                setOpen(false);
+              }}
+              className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {getTeamInfo(team).fullName}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeamDropdown;


### PR DESCRIPTION
## Summary
- introduce `CalendarDropdown` and `TeamDropdown` components
- swap `<select>` elements for new dropdowns in `App`
- compute game dates with `useMemo` to highlight on the calendar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf4738cd08331a0966e0ac69b6e34