### PR TITLE
Improve lineup messages

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -108,7 +108,43 @@ const LineupTab = ({
           ) : (
             <div className="text-center py-8 text-gray-500">
               <Music className="w-12 h-12 mx-auto mb-4 opacity-50" />
-              <p>라인업 정보가 없습니다</p>
+              {(() => {
+                const selected = new Date(selectedDate);
+                const today = new Date();
+                const isToday =
+                  selected.toDateString() === today.toDateString();
+                if (isToday) {
+                  return (
+                    <>
+                      <p>오늘 라인업이 아직 올라오지 않았습니다</p>
+                      <p className="text-sm mt-2">최근 라인업 보러가실래요?</p>
+                    </>
+                  );
+                }
+                return <p>라인업 정보가 없습니다</p>;
+              })()}
+              <button
+                onClick={() => {
+                  const recentGame = gameLineups
+                    .filter((game) => {
+                      const idParts = game.id.split('_');
+                      return idParts.length === 2 && idParts[1] === selectedTeam;
+                    })
+                    .sort((a, b) => {
+                      const dateA = a.id.split('_')[0];
+                      const dateB = b.id.split('_')[0];
+                      return dateB.localeCompare(dateA);
+                    })[0];
+
+                  if (recentGame) {
+                    const recentDate = recentGame.id.split('_')[0];
+                    setSelectedDate(recentDate);
+                  }
+                }}
+                className="mt-4 bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors"
+              >
+                최근 라인업 보러가기
+              </button>
             </div>
           )}
         </>


### PR DESCRIPTION
## Summary
- tweak `LineupTab` to show a friendly message when today's lineup isn't out yet
- provide quick access to the most recent lineup in that case

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa6daa70833197519cb3b6cf5d82