### PR TITLE
Add schedule tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,8 @@ import {
   AlertCircle,
   Trophy,
   Sun,
-  Moon
+  Moon,
+  Calendar
 } from 'lucide-react';
 import ChantCard from './components/ChantCard';
 import LyricsSection from './components/LyricsSection';
@@ -29,6 +30,7 @@ import { getTeamInfo, getPositionKorean, getBattingOrder } from './utils/team';
 import PlayerTab from './components/PlayerTab';
 import ExploreTab from './components/ExploreTab';
 import TeamChantsTab from './components/TeamChantsTab';
+import ScheduleTab from './components/ScheduleTab';
 import CalendarDropdown from './components/CalendarDropdown';
 import TeamDropdown from './components/TeamDropdown';
 import useKboData from './hooks/useKboData';
@@ -96,7 +98,7 @@ const JikgwanGaja = () => {
 
     const setTabFromHash = () => {
       const tab = window.location.hash.replace('#', '');
-      if (tab && ['lineup', 'teamChants', 'explore'].includes(tab)) {
+      if (tab && ['lineup', 'teamChants', 'explore', 'schedule'].includes(tab)) {
         setActiveTab(tab);
         setShowPlayer(false);
       }
@@ -744,6 +746,20 @@ const getSortedChants = () => {
           <Search className="w-6 h-6" />
           <span className="text-xs">탐색</span>
         </button>
+        <button
+          onClick={() => {
+            setActiveTab('schedule');
+            setShowPlayer(false);
+          }}
+          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
+            activeTab === 'schedule' && !showPlayer
+              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
+              : 'text-gray-600'
+          }`}
+        >
+          <Calendar className="w-6 h-6" />
+          <span className="text-xs">일정</span>
+        </button>
       </div>
 
      {/* 메인 콘텐츠 */}
@@ -827,6 +843,13 @@ const getSortedChants = () => {
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}
                 setCurrentPlayerName={setCurrentPlayerName}
+              />
+            )}
+            {activeTab === 'schedule' && (
+              <ScheduleTab
+                selectedTeam={selectedTeam}
+                gameLineups={gameLineups}
+                formatDateKorean={formatDateKorean}
               />
             )}
           </>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import { getTeamInfo } from '../utils/team';
+
+const ScheduleTab = ({ selectedTeam, gameLineups, formatDateKorean }) => {
+  const schedules = gameLineups
+    .filter((game) => game.team === selectedTeam)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return (
+    <div className="space-y-3">
+      {schedules.map((game) => (
+        <div
+          key={game.id}
+          className="flex items-center justify-between bg-white dark:bg-gray-700 rounded-lg p-3 shadow"
+        >
+          <div className="flex items-center gap-2">
+            {getTeamInfo(game.away).logo && (
+              <img
+                src={getTeamInfo(game.away).logo}
+                alt={game.away}
+                className="w-5 h-5 object-contain"
+              />
+            )}
+            <span className="font-medium">{game.away}</span>
+            <span className="mx-1 text-gray-500">vs</span>
+            {getTeamInfo(game.home).logo && (
+              <img
+                src={getTeamInfo(game.home).logo}
+                alt={game.home}
+                className="w-5 h-5 object-contain"
+              />
+            )}
+            <span className="font-medium">{game.home}</span>
+          </div>
+          <div className="text-sm text-right text-gray-600 dark:text-gray-300">
+            <div>{game.gameTime || '미정'}</div>
+            <div>
+              {formatDateKorean(game.date)}
+              {game.gameStatus ? ` • ${game.gameStatus}` : ''}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScheduleTab;
+

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -217,6 +217,9 @@ const useKboData = () => {
             const awayTeam = normalizeTeamName(game.teams?.find((t) => !t.is_home)?.name || '');
             const dateStr = normalizeDate(game.date);
             const location = game.location || '미정';
+            const gameTime = game.game_time
+              ? game.game_time.replace('경기 시간', '').trim()
+              : '미정';
 
             if (!dateStr) {
               console.warn('유효하지 않은 날짜:', game.date, file);
@@ -257,6 +260,7 @@ const useKboData = () => {
                 home: homeTeam,
                 away: awayTeam,
                 location: location,
+                gameTime: gameTime,
                 lineup: lineup1,
                 canceled: isCanceled,
                 gameStatus: game.game_status,
@@ -268,6 +272,7 @@ const useKboData = () => {
                 home: homeTeam,
                 away: awayTeam,
                 location: location,
+                gameTime: gameTime,
                 lineup: lineup2,
                 canceled: isCanceled,
                 gameStatus: game.game_status,


### PR DESCRIPTION
## Summary
- parse game time in data loader
- add Schedule tab displaying upcoming games with team logos

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa7126a08331933ffede78c73d1b