### PR TITLE
Show previous and next player names

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByText(/직관가자/i);
+  expect(titleElement).toBeInTheDocument();
 });

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -61,6 +61,15 @@ const PlayerTab = ({
     logRequest(currentChant.playerName, 'song');
     alert(`${currentChant.playerName} 선수에 대한 요청이 완료되었습니다.`);
   };
+
+  const prevPlayerName =
+    playSource === 'lineup'
+      ? currentLineup[currentLineupIndex - 1]?.playerName
+      : playerSongs[currentPlayer - 1]?.playerName;
+  const nextPlayerName =
+    playSource === 'lineup'
+      ? currentLineup[currentLineupIndex + 1]?.playerName
+      : playerSongs[currentPlayer + 1]?.playerName;
   return (
     <div className="space-y-4">
       {/* 선수 상세 정보 카드 */}
@@ -171,25 +180,32 @@ const PlayerTab = ({
         defaultExpanded
       />
       {/* 컨트롤 버튼 */}
-      <div className="flex items-center justify-center gap-12">
+      <div className="flex items-center justify-between gap-4 py-4">
         <button
           onClick={playPrev}
           disabled={
             (playSource === 'explore' && currentPlayer === 0) ||
             (playSource === 'lineup' && currentLineupIndex === 0)
           }
-          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
+          className="flex items-center gap-2 p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
         >
           <SkipBack className="w-6 h-6" />
+          {prevPlayerName && (
+            <span className="text-sm text-gray-700">{prevPlayerName}</span>
+          )}
         </button>
         <button
           onClick={playNext}
           disabled={
             (playSource === 'explore' && currentPlayer === playerSongs.length - 1) ||
-            (playSource === 'lineup' && currentLineupIndex === currentLineup.length - 1)
+            (playSource === 'lineup' &&
+              currentLineupIndex === currentLineup.length - 1)
           }
-          className="p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
+          className="flex items-center gap-2 p-3 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
         >
+          {nextPlayerName && (
+            <span className="text-sm text-gray-700">{nextPlayerName}</span>
+          )}
           <SkipForward className="w-6 h-6" />
         </button>
       </div>


### PR DESCRIPTION
## Summary
- display lineup neighbor names in the player playback view
- update default test to look for the page title

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa7594fc8331957f3c9137803826