### PR TITLE
Fix calendar dropdown width

### DIFF
--- a/src/components/CalendarDropdown.jsx
+++ b/src/components/CalendarDropdown.jsx
@@ -70,8 +70,8 @@ const CalendarDropdown = ({ value, onChange, gameDates }) => {
         {formatLabel(new Date(value))}
         <ChevronDown className="w-4 h-4 ml-2" />
       </button>
-      {open && (
-        <div className="absolute z-10 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-4">
+        {open && (
+        <div className="absolute z-10 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-4 w-72">
           <div className="flex items-center justify-between mb-2">
             <button onClick={prevMonth} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded">
               <ChevronLeft className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- expand the calendar dropdown so dates don't overlap

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cffe31460833189661aa9f97cd452