### PR TITLE
Add missing KIA outfielder data

### DIFF
--- a/public/data/kboPlayers.json
+++ b/public/data/kboPlayers.json
@@ -3398,5 +3398,15 @@
     "throwBat": "우투좌타",
     "birth": "1989-01-10T15:00:00.000Z",
     "body": "184cm, 83kg"
+  },
+  {
+    "teamCode": "HT",
+    "teamName": "KIA",
+    "number": "36",
+    "playerName": "이창진",
+    "position": "외야수",
+    "throwBat": "우투우타",
+    "birth": "1990-07-17T15:00:00.000Z",
+    "body": "180cm, 80kg"
   }
 ]

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -8,6 +8,7 @@ const normalizeTeamName = (teamName) => {
     hanwha: '한화',
     KIA: 'KIA',
     kia: 'KIA',
+    기아: 'KIA',
     두산: '두산',
     Doosan: '두산',
     doosan: '두산',


### PR DESCRIPTION
## Summary
- normalize '기아' as 'KIA'
- add missing KIA outfielder Lee Chang-jin to `kboPlayers.json`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d12894d948331999390e59f158ddf