### PR TITLE
Add remaining-games summary in schedule

### DIFF
--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -1,14 +1,74 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Calendar } from 'lucide-react';
 import { getTeamInfo } from '../utils/team';
+
+const ALL_TEAMS = [
+  'KIA',
+  '두산',
+  'LG',
+  '삼성',
+  '롯데',
+  'SSG',
+  '키움',
+  '한화',
+  'NC',
+  'KT',
+];
 
 const ScheduleTab = ({ selectedTeam, gameLineups, formatDateKorean }) => {
   const schedules = gameLineups
     .filter((game) => game.team === selectedTeam)
     .sort((a, b) => a.date.localeCompare(b.date));
 
+  const opponentStats = useMemo(() => {
+    const stats = {};
+    ALL_TEAMS.forEach((team) => {
+      if (team !== selectedTeam) {
+        stats[team] = { played: 0, remaining: 16 };
+      }
+    });
+
+    schedules.forEach((game) => {
+      const opponent = game.home === selectedTeam ? game.away : game.home;
+      if (!stats[opponent]) return;
+      const isFinished =
+        game.gameStatus && game.gameStatus.includes('종료');
+      if (isFinished) {
+        stats[opponent].played += 1;
+        stats[opponent].remaining = Math.max(
+          16 - stats[opponent].played,
+          0
+        );
+      }
+    });
+
+    return stats;
+  }, [schedules, selectedTeam]);
+
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        {Object.entries(opponentStats).map(([team, info]) => (
+          <div
+            key={team}
+            className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded-md p-2 text-sm"
+          >
+            <div className="flex items-center gap-1">
+              {getTeamInfo(team).logo && (
+                <img
+                  src={getTeamInfo(team).logo}
+                  alt={team}
+                  className="w-4 h-4 object-contain"
+                />
+              )}
+              <span className="font-medium">{team}</span>
+            </div>
+            <span>
+              {info.played}경기 • {info.remaining}남음
+            </span>
+          </div>
+        ))}
+      </div>
       {schedules.map((game) => (
         <div
           key={game.id}


### PR DESCRIPTION
## Summary
- show how many games have been played and remain for each opponent

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d16265a20833182680105be37b7bd