### PR TITLE
Fix schedule sorting

### DIFF
--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -18,7 +18,7 @@ const ALL_TEAMS = [
 const ScheduleTab = ({ selectedTeam, gameLineups, formatDateKorean }) => {
   const schedules = gameLineups
     .filter((game) => game.team === selectedTeam)
-    .sort((a, b) => a.date.localeCompare(b.date));
+    .sort((a, b) => b.date.localeCompare(a.date));
 
   const opponentStats = useMemo(() => {
     const stats = {};


### PR DESCRIPTION
## Summary
- sort team schedule by most recent games

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d17b1fc7483318c88145ac4b7036e