### PR TITLE
Add lineup logos and schedule link

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -835,6 +835,8 @@ const getSortedChants = () => {
                 selectedTeam={selectedTeam}
                 gameLineups={gameLineups}
                 formatDateKorean={formatDateKorean}
+                setSelectedDate={setSelectedDate}
+                setActiveTab={setActiveTab}
               />
             )}
           </>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PlayerCard from './PlayerCard';
 import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
+import { getTeamInfo } from '../utils/team';
 
 const LineupTab = ({
   currentLineup,
@@ -64,9 +65,29 @@ const LineupTab = ({
           <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-4 mb-4 shadow-sm">
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
               <div>
-                <h3 className="font-semibold text-gray-800 dark:text-gray-100">
-                  {currentGame.home} vs {currentGame.away}
-                </h3>
+                <div className="flex items-center gap-2">
+                  {getTeamInfo(currentGame.away).logo && (
+                    <img
+                      src={getTeamInfo(currentGame.away).logo}
+                      alt={currentGame.away}
+                      className="w-5 h-5 object-contain"
+                    />
+                  )}
+                  <span className="font-semibold text-gray-800 dark:text-gray-100">
+                    {currentGame.away}
+                  </span>
+                  <span className="mx-1 text-gray-500">vs</span>
+                  {getTeamInfo(currentGame.home).logo && (
+                    <img
+                      src={getTeamInfo(currentGame.home).logo}
+                      alt={currentGame.home}
+                      className="w-5 h-5 object-contain"
+                    />
+                  )}
+                  <span className="font-semibold text-gray-800 dark:text-gray-100">
+                    {currentGame.home}
+                  </span>
+                </div>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
                   {currentGame.location} • {formatDateKorean(currentGame.date)}
                   {currentGame.gameStatus && ` • ${currentGame.gameStatus}`}

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -15,7 +15,13 @@ const ALL_TEAMS = [
   'KT',
 ];
 
-const ScheduleTab = ({ selectedTeam, gameLineups, formatDateKorean }) => {
+const ScheduleTab = ({
+  selectedTeam,
+  gameLineups,
+  formatDateKorean,
+  setSelectedDate,
+  setActiveTab,
+}) => {
   const schedules = gameLineups
     .filter((game) => game.team === selectedTeam)
     .sort((a, b) => b.date.localeCompare(a.date));
@@ -72,7 +78,16 @@ const ScheduleTab = ({ selectedTeam, gameLineups, formatDateKorean }) => {
       {schedules.map((game) => (
         <div
           key={game.id}
-          className="flex items-center justify-between bg-white dark:bg-gray-700 rounded-lg p-3 shadow"
+          onClick={() => {
+            if (setSelectedDate) {
+              const date = new Date(game.date).toISOString().split('T')[0];
+              setSelectedDate(date);
+            }
+            if (setActiveTab) {
+              setActiveTab('lineup');
+            }
+          }}
+          className="flex items-center justify-between bg-white dark:bg-gray-700 rounded-lg p-3 shadow cursor-pointer"
         >
           <div className="flex items-center gap-2">
             {getTeamInfo(game.away).logo && (


### PR DESCRIPTION
## Summary
- show team logos in `LineupTab`
- allow schedule click to jump to that game's lineup

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1975edbc83318121ef113a4415c7