### PR TITLE
Support doubleheader games in schedules

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -183,7 +183,9 @@ const JikgwanGaja = () => {
         gameLineups
           .filter((game) => {
             const parts = game.id.split('_');
-            return parts.length === 2 && parts[1] === selectedTeam;
+            return (
+              parts.length >= 2 && parts[parts.length - 1] === selectedTeam
+            );
           })
           .map((game) => game.id.split('_')[0])
       ),
@@ -289,7 +291,7 @@ const JikgwanGaja = () => {
         debugLog('잘못된 게임 ID 형식:', game.id);
         return false;
       }
-  
+
       const gameDateStr = idParts[0];
       const gameTeam = idParts[idParts.length - 1];
       const gameDateISO = normalizeDate(gameDateStr);
@@ -444,7 +446,7 @@ const JikgwanGaja = () => {
   
       // 새로운 ID 구조 "YYYY-MM-DD_팀명" 처리
       const idParts = game.id.split('_');
-      if (idParts.length !== 2) return false;
+      if (idParts.length < 2) return false;
   
       const gameDateStr = idParts[0]; // YYYY-MM-DD
       const gameTeam = idParts[1];    // 팀명

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -138,7 +138,10 @@ const LineupTab = ({
                   const recentGame = gameLineups
                     .filter((game) => {
                       const idParts = game.id.split('_');
-                      return idParts.length === 2 && idParts[1] === selectedTeam;
+                      return (
+                        idParts.length >= 2 &&
+                        idParts[idParts.length - 1] === selectedTeam
+                      );
                     })
                     .sort((a, b) => {
                       const dateA = a.id.split('_')[0];
@@ -205,7 +208,10 @@ const LineupTab = ({
               const recentGame = gameLineups
                 .filter((game) => {
                   const idParts = game.id.split('_');
-                  return idParts.length === 2 && idParts[1] === selectedTeam;
+                  return (
+                    idParts.length >= 2 &&
+                    idParts[idParts.length - 1] === selectedTeam
+                  );
                 })
                 .sort((a, b) => {
                   const dateA = a.id.split('_')[0];

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -214,8 +214,12 @@ const useKboData = () => {
           }
 
           try {
-            const homeTeam = normalizeTeamName(game.teams?.find((t) => t.is_home)?.name || '');
-            const awayTeam = normalizeTeamName(game.teams?.find((t) => !t.is_home)?.name || '');
+            const homeTeam = normalizeTeamName(
+              game.teams?.find((t) => t.is_home)?.name || ''
+            );
+            const awayTeam = normalizeTeamName(
+              game.teams?.find((t) => !t.is_home)?.name || ''
+            );
             const dateStr = normalizeDate(game.date);
             const location = game.location || '미정';
             const gameTime = game.game_time
@@ -250,12 +254,17 @@ const useKboData = () => {
               return [];
             }
 
-            const lineup1 = isCanceled ? [] : buildLineup(game.starting_lineups?.team_1, team1Name);
-            const lineup2 = isCanceled ? [] : buildLineup(game.starting_lineups?.team_2, team2Name);
+            const lineup1 = isCanceled
+              ? []
+              : buildLineup(game.starting_lineups?.team_1, team1Name);
+            const lineup2 = isCanceled
+              ? []
+              : buildLineup(game.starting_lineups?.team_2, team2Name);
 
             return [
               {
-                id: `${dateStr}_${team1Name}`,
+                id: `${dateStr}_${game.game_code}_${team1Name}`,
+                gameCode: game.game_code,
                 date: dateStr,
                 team: team1Name,
                 home: homeTeam,
@@ -267,7 +276,8 @@ const useKboData = () => {
                 gameStatus: game.game_status,
               },
               {
-                id: `${dateStr}_${team2Name}`,
+                id: `${dateStr}_${game.game_code}_${team2Name}`,
+                gameCode: game.game_code,
                 date: dateStr,
                 team: team2Name,
                 home: homeTeam,


### PR DESCRIPTION
## Summary
- include game code when parsing lineups so each game is unique
- update schedule-related logic to handle IDs with game codes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d67adefbc8331a9589b703aa480b1