### PR TITLE
Add prestart and prebuild scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "prestart": "npm run build-lineup-index",
+    "prebuild": "npm run build-lineup-index",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
## Summary
- rebuild lineup index before running dev server or build

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d76a28a6c8331ad3d74bc1b7a0c97