### PR TITLE
Fix lineup loading

### DIFF
--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -115,7 +115,6 @@ const useKboData = () => {
     setError(null);
     try {
       const base = process.env.PUBLIC_URL || '';
-<<<<<<< ggid1v-codex/라인업-표시-안되는-문제-해결
 
       const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
@@ -123,19 +122,6 @@ const useKboData = () => {
         fetchSafeJson(`${base}/data/teamChants.json`, []),
         fetchSafeJson(`${base}/data/kboPlayers.json`, []),
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
-=======
-      
-      // 병렬로 데이터 로드 (라인업 인덱스가 실패하면 null 반환)
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups] = await Promise.all([
-        fetch(`${base}/data/playerSongs.json`).then((res) => res.json()),
-        fetch(`${base}/data/kbo_crawler_data/index.json`).then((res) => res.json()).catch((err) => {
-          console.warn('index.json 로드 실패', err);
-          return null;
-        }),
-        fetch(`${base}/data/teamChants.json`).then((res) => res.json()),
-        fetch(`${base}/data/kboPlayers.json`).then((res) => res.json()),
-        fetch(`${base}/data/gameLineups.json`).then((res) => res.json()).catch(() => []),
->>>>>>> main
       ]);
 
       console.log('로드된 데이터:', {


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in useKboData hook so JSON data loads correctly

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d775e40e48331bd915e843705acb4