### PR TITLE
Expose player IDs in kboPlayers data

### DIFF
--- a/public/kbo_players_crawler.py
+++ b/public/kbo_players_crawler.py
@@ -117,6 +117,14 @@ def _scrape_team(driver: webdriver.Chrome, code: str) -> list:
                     throwbat = ""
                 else:
                     number, name, team, position, throwbat, birth, body, school = cols[:8]
+
+                player_id = ""
+                link = row.find("a", href=True)
+                if link and "playerId=" in link["href"]:
+                    m = re.search(r"playerId=(\d+)", link["href"])
+                    if m:
+                        player_id = m.group(1)
+
                 player = {
                     "teamCode": code,
                     "teamName": TEAM_CODES.get(code, ""),
@@ -127,6 +135,7 @@ def _scrape_team(driver: webdriver.Chrome, code: str) -> list:
                     "birth": _parse_date(birth),
                     "body": body,
                     "school": school,
+                    "playerId": player_id,
                 }
                 players.append(player)
             print(f"{TEAM_CODES.get(code, code)}: {len(players)}명 (페이지 {page_num} 이동, 실제 페이지: {current_page})")

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -148,6 +148,7 @@ const useKboData = () => {
 
         return {
           id: `${teamName}_${player.playerName}`,
+          playerId: player.playerId || '',
           playerName: player.playerName,
           team: teamName,
           chantTitle: matchedSong?.chantTitle || `${player.playerName} 응원가`,


### PR DESCRIPTION
## Summary
- extract `playerId` from each player profile link when crawling
- include new `playerId` in song objects returned by `useKboData`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685deaecd70c83318bd23399bdc20d3b