### PR TITLE
Add double-header detection and dropdown labels

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -434,7 +434,7 @@ const JikgwanGaja = () => {
 
     const selectedDateISO = normalizeDate(selectedDate);
 
-    return gameLineups
+    const filtered = gameLineups
       .filter((game) => {
         if (!game || !game.id) return false;
         const parts = game.id.split('_');
@@ -445,6 +445,23 @@ const JikgwanGaja = () => {
         return gameDateISO === selectedDateISO && team === selectedTeam;
       })
       .sort((a, b) => parseTime(a.gameTime) - parseTime(b.gameTime));
+
+    const groups = {};
+    filtered.forEach((g) => {
+      const key = `${g.date}_${g.home}_${g.away}`;
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(g);
+    });
+
+    return filtered.map((g) => {
+      const key = `${g.date}_${g.home}_${g.away}`;
+      const group = groups[key];
+      if (group.length > 1) {
+        const index = group.indexOf(g);
+        return { ...g, dhOrder: index + 1 };
+      }
+      return g;
+    });
   };
   
   const getCurrentGame = () => {

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -58,7 +58,7 @@ const LineupTab = ({
           >
             {availableGames.map((g) => (
               <option key={g.gameCode} value={g.gameCode}>
-                {g.gameTime || g.gameCode}
+                {g.gameTime} {g.dhOrder ? `(DH${g.dhOrder})` : ''}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- assign `dhOrder` inside `getTodayGames` for games that share the same date/home/away
- show double-header info in LineupTab game selection dropdown

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685deae6b2e08331b483016121761ed7