### PR TITLE
Add double-header handling to schedule stats

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -434,7 +434,7 @@ const JikgwanGaja = () => {
 
     const selectedDateISO = normalizeDate(selectedDate);
 
-    return gameLineups
+    const filtered = gameLineups
       .filter((game) => {
         if (!game || !game.id) return false;
         const parts = game.id.split('_');
@@ -445,6 +445,23 @@ const JikgwanGaja = () => {
         return gameDateISO === selectedDateISO && team === selectedTeam;
       })
       .sort((a, b) => parseTime(a.gameTime) - parseTime(b.gameTime));
+
+    const groups = {};
+    filtered.forEach((g) => {
+      const key = `${g.date}_${g.home}_${g.away}`;
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(g);
+    });
+
+    return filtered.map((g) => {
+      const key = `${g.date}_${g.home}_${g.away}`;
+      const group = groups[key];
+      if (group.length > 1) {
+        const index = group.indexOf(g);
+        return { ...g, dhOrder: index + 1 };
+      }
+      return g;
+    });
   };
   
   const getCurrentGame = () => {

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -58,7 +58,7 @@ const LineupTab = ({
           >
             {availableGames.map((g) => (
               <option key={g.gameCode} value={g.gameCode}>
-                {g.gameTime || g.gameCode}
+                {g.gameTime} {g.dhOrder ? `(DH${g.dhOrder})` : ''}
               </option>
             ))}
           </select>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -35,26 +35,26 @@ const ScheduleTab = ({
   });
 
   const opponentStats = useMemo(() => {
-    const perTeamTotal = locationFilter === '전체' ? 16 : 8;
     const stats = {};
     ALL_TEAMS.forEach((team) => {
       if (team !== selectedTeam) {
-        stats[team] = { played: 0, remaining: perTeamTotal };
+        stats[team] = { played: 0, total: 0, remaining: 0 };
       }
     });
 
     filteredSchedules.forEach((game) => {
       const opponent = game.home === selectedTeam ? game.away : game.home;
       if (!stats[opponent]) return;
+      stats[opponent].total += 1;
       const isFinished =
         !game.canceled && game.gameStatus && game.gameStatus.includes('종료');
       if (isFinished) {
         stats[opponent].played += 1;
-        stats[opponent].remaining = Math.max(
-          perTeamTotal - stats[opponent].played,
-          0
-        );
       }
+    });
+
+    Object.values(stats).forEach((info) => {
+      info.remaining = Math.max(info.total - info.played, 0);
     });
 
     return stats;


### PR DESCRIPTION
## Summary
- assign `dhOrder` to games in `getTodayGames` so double-headers appear in the lineup dropdown
- show `DH1`/`DH2` labels in game select
- compute opponent schedule stats using actual game count so double headers count correctly

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685deae6b2e08331b483016121761ed7