### PR TITLE
Add workflow to update player song mapping

### DIFF
--- a/.github/workflows/update-player-song-mapping.yml
+++ b/.github/workflows/update-player-song-mapping.yml
@@ -1,0 +1,30 @@
+name: Update player song mapping
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-mapping:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Update player song mapping
+        run: node scripts/updatePlayerSongTeams.js
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/playerSongs.json
+          git commit -m "Update player song mapping" || echo "No changes to commit"
+          git pull --rebase origin main
+          git push origin main

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "build-lineup-index": "node scripts/generateLineupIndex.js"
+    "build-lineup-index": "node scripts/generateLineupIndex.js",
+    "update-song-mapping": "node scripts/updatePlayerSongTeams.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/updatePlayerSongTeams.js
+++ b/scripts/updatePlayerSongTeams.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const playerSongsPath = path.join(__dirname, '..', 'public', 'data', 'playerSongs.json');
+const kboPlayersPath = path.join(__dirname, '..', 'public', 'data', 'kboPlayers.json');
+
+const playerSongs = JSON.parse(fs.readFileSync(playerSongsPath, 'utf8'));
+const kboPlayers = JSON.parse(fs.readFileSync(kboPlayersPath, 'utf8'));
+
+const playerTeamMap = new Map();
+for (const player of kboPlayers) {
+  if (player.playerName && player.teamName) {
+    playerTeamMap.set(player.playerName, player.teamName);
+  }
+}
+
+let updatedCount = 0;
+for (const song of playerSongs) {
+  const teamName = playerTeamMap.get(song.playerName);
+  if (teamName && song.team !== teamName) {
+    song.team = teamName;
+    updatedCount++;
+  }
+}
+
+if (updatedCount > 0) {
+  fs.writeFileSync(playerSongsPath, JSON.stringify(playerSongs, null, 2));
+  console.log(`Updated ${updatedCount} player song entries with team names`);
+} else {
+  console.log('No updates needed');
+}


### PR DESCRIPTION
## Summary
- add Node script to sync `playerSongs.json` team names with official KBO player data
- add GitHub Actions workflow to run the sync manually
- expose new script via npm

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dec6666108331bc0f278ddd9d7c4a