### PR TITLE
Update lineup crawl workflow

### DIFF
--- a/.github/workflows/lineup-crawl.yml
+++ b/.github/workflows/lineup-crawl.yml
@@ -76,12 +76,15 @@ jobs:
 
       - name: Rebuild lineup index
         run: npm run build-lineup-index
+
+      - name: Sync player songs
+        run: npm run update-song-mapping
         
       - name: Commit and push
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add public/data/kbo_crawler_data
+          git add public/data/kbo_crawler_data public/data/playerSongs.json
           git commit -m "Daily data update" || echo "No changes to commit"
           git pull --rebase origin main
           git push origin main

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Edit the JSON files directly inside `public/data/` or generate new lineup files 
 
 ```bash
 npm run build-lineup-index
+npm run update-song-mapping
 ```
 
 ## Crawling lineups
@@ -48,7 +49,7 @@ python public/kbo_players_crawler.py
 
 Two GitHub Actions workflows keep the data updated:
 
-- `.github/workflows/lineup-crawl.yml` fetches new lineups several times each day and rebuilds `public/data/kbo_crawler_data/index.json`.
+ - `.github/workflows/lineup-crawl.yml` fetches new lineups several times each day, rebuilds `public/data/kbo_crawler_data/index.json` and syncs `public/data/playerSongs.json` with the latest player info.
 - `.github/workflows/player-crawl.yml` updates `public/data/kboPlayers.json` daily at 00:00 UTC.
 
 Both workflows commit any changes back to the repository automatically.


### PR DESCRIPTION
## Summary
- rebuild lineup index and sync player songs in the daily crawl workflow
- document new sync step in README

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e120c6300833192754c922e75cda1