### PR TITLE
Implement batter-only filter in explore tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -51,6 +51,7 @@ const JikgwanGaja = () => {
   
   const [exploreTeamFilter, setExploreTeamFilter] = useState('전체');
   const [hasSongOnly, setHasSongOnly] = useState(false);
+  const [hasBatterOnly, setHasBatterOnly] = useState(false);
 
   const [currentPlayer, setCurrentPlayer] = useState(0);
   const [activeTab, setActiveTab] = useState('lineup');
@@ -534,6 +535,10 @@ const getSortedChants = () => {
       return false;
     }
 
+    if (hasBatterOnly && getPositionKorean(chant.position) === '투수') {
+      return false;
+    }
+
     if (hasSongOnly && !chant.youtubeId) {
       return false;
     }
@@ -875,6 +880,8 @@ const getSortedChants = () => {
                 setExploreTeamFilter={setExploreTeamFilter}
                 hasSongOnly={hasSongOnly}
                 setHasSongOnly={setHasSongOnly}
+                hasBatterOnly={hasBatterOnly}
+                setHasBatterOnly={setHasBatterOnly}
                 playerSongs={playerSongs}
                 kboPlayers={kboPlayers}
                 rawSongs={rawSongs}

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Search,
   Filter,
@@ -18,6 +18,8 @@ const ExploreTab = ({
   setSortBy,
   hasSongOnly,
   setHasSongOnly,
+  hasBatterOnly,
+  setHasBatterOnly,
   playerSongs,
   kboPlayers,
   rawSongs,
@@ -33,7 +35,6 @@ const ExploreTab = ({
   isComposing,
   setCurrentPlayerName,
 }) => {
-  const [hasBatterOnly, setHasBatterOnly] = useState(false);
   const teamOptions = [
     'KIA',
     '두산',


### PR DESCRIPTION
## Summary
- add `hasBatterOnly` state to App
- filter pitchers when batter-only is checked
- pass `hasBatterOnly` to `ExploreTab`
- handle checkbox state in `ExploreTab`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f32fd4b5c8331bd89d5fe5dc8ab99