### PR TITLE
Update main chant button transparency

### DIFF
--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -79,7 +79,7 @@ const TeamChantsTab = ({
                     ? {
                         backgroundColor: hexToRgba(
                           getTeamInfo(selectedTeam).color,
-                          0.7
+                          0.3
                         ),
                         borderColor: getTeamInfo(selectedTeam).color,
                       }


### PR DESCRIPTION
## Summary
- make the '대표 응원가' button background more transparent

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d0621b988331a6128a3cadaba86a