### PR TITLE
Update main chant text color

### DIFF
--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -73,13 +73,13 @@ const TeamChantsTab = ({
               <button
                 key={chant.id}
                 onClick={() => scrollToChant(chant.id)}
-                className={`text-xs px-3 py-1 border rounded-lg whitespace-nowrap ${isMain ? 'text-white' : 'text-gray-900'}`}
+                className={`text-xs px-3 py-1 border rounded-lg whitespace-nowrap ${isMain ? 'text-black' : 'text-gray-900'}`}
                 style={
                   isMain
                     ? {
                         backgroundColor: hexToRgba(
                           getTeamInfo(selectedTeam).color,
-                          0.7
+                          0.3
                         ),
                         borderColor: getTeamInfo(selectedTeam).color,
                       }


### PR DESCRIPTION
## Summary
- make the `대표 응원가` button text black so it's readable against a transparent background

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d0621b988331a6128a3cadaba86a