### PR TITLE
Add floating scroll-to-top button

### DIFF
--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronUp } from 'lucide-react';
+
+const ScrollToTopButton = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.pageYOffset > 300) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`fixed bottom-6 right-6 p-3 bg-blue-500 text-white rounded-full shadow-lg transition-opacity ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      aria-label="맨 위로"
+    >
+      <ChevronUp className="w-5 h-5" />
+    </button>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -4,6 +4,7 @@ import LyricsSection from './LyricsSection';
 import TeamChantVideo from './TeamChantVideo';
 import { getTeamInfo } from '../utils/team';
 import { hexToRgba } from '../utils/color';
+import ScrollToTopButton from './ScrollToTopButton';
 
 const TeamChantsTab = ({
   teamChants,
@@ -53,7 +54,7 @@ const TeamChantsTab = ({
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 relative">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-2xl font-bold text-gray-900">
           {selectedTeam} 팀 응원가
@@ -155,6 +156,7 @@ const TeamChantsTab = ({
           </div>
         ))
       )}
+      <ScrollToTopButton />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- introduce `ScrollToTopButton` component for quickly returning to page top
- display the new floating button in the TeamChantsTab screen

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d2cedc488331bc955b119dbebf7c