### PR TITLE
Document first-song usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ npm run build # build for production
 
 Running these commands requires **Node.js 20 or later**.
 
+## Handling multiple songs per player
+
+Some players have more than one walk‑up song. When the app opens a player
+profile (for example by clicking a player card), it simply uses the **first**
+matching song in `playerSongs`. This means that duplicates are supported but the
+UI always plays the first entry it finds. No uniqueness is assumed in the code
+path – additional songs can be added as separate records in
+`public/data/playerSongs.json`.
+
 ## Sharing lineups
 
 Use the "오늘의 라인업 공유하기" button in the lineup tab to share or copy the current team's lineup.

--- a/src/App.js
+++ b/src/App.js
@@ -206,6 +206,8 @@ const JikgwanGaja = () => {
 
   useEffect(() => {
     if (pendingPlayerName && playerSongs.length > 0) {
+      // Find the first matching song for the requested player.
+      // Multiple entries may exist; we simply use the first one here.
       const idx = playerSongs.findIndex(
         (song) =>
           song.playerName === pendingPlayerName && song.team === selectedTeam
@@ -327,7 +329,8 @@ const JikgwanGaja = () => {
         // 만약 lineupPlayer에 선발투수 정보가 있을 때 null 체크
         const pitcherName = lineupPlayer.starting_pitcher?.name || "-";
   
-        const song = playerSongs.find(song => 
+        // Only the first matching song is used for lineup display.
+        const song = playerSongs.find(song =>
           song && song.playerName === lineupPlayer.playerName && song.team === selectedTeam
         );
   
@@ -523,13 +526,17 @@ const JikgwanGaja = () => {
   };
 
 
-// getSortedChants 함수 수정 - 가나다순 정렬만 지원
+// getSortedChants: return a name-sorted list of all song records.
+// Multiple songs for a single player are kept as-is and sorted
+// alongside one another.
 const getSortedChants = () => {
   return [...playerSongs].sort((a, b) =>
     a.playerName.localeCompare(b.playerName, 'ko')
   );
 };
 
+  // Apply filters to the sorted list. Each record is processed independently
+  // so multiple songs for the same player will all appear if they match.
   const filteredChants = getSortedChants().filter(chant => {
     // 팀 필터링
     if (exploreTeamFilter !== '전체' && chant.team !== exploreTeamFilter) {
@@ -568,7 +575,8 @@ const getSortedChants = () => {
         const nextLineupIndex = currentLineupIndex + 1;
         const nextPlayer = currentLineup[nextLineupIndex];
         
-        const globalIndex = playerSongs.findIndex(song => 
+        // Determine the first matching song entry for the next lineup player.
+        const globalIndex = playerSongs.findIndex(song =>
           song.playerName === nextPlayer.playerName && song.team === selectedTeam
         );
         
@@ -592,7 +600,8 @@ const getSortedChants = () => {
         const prevLineupIndex = currentLineupIndex - 1;
         const prevPlayer = currentLineup[prevLineupIndex];
         
-        const globalIndex = playerSongs.findIndex(song => 
+        // Determine the first matching song entry for the previous lineup player.
+        const globalIndex = playerSongs.findIndex(song =>
           song.playerName === prevPlayer.playerName && song.team === selectedTeam
         );
         

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -12,6 +12,8 @@ const ChantCard = ({
   setCurrentPlayerName
 }) => {
   const openPlayer = () => {
+    // Each song record has a unique id. If multiple songs exist for a player
+    // they are stored separately. Here we simply use the first match.
     const playerIndex = playerSongs.findIndex(c => c.id === chant.id);
     if (playerIndex !== -1) {
       setCurrentPlayer(playerIndex);

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -14,6 +14,9 @@ const PlayerCard = ({
   setCurrentPlayerName,
 }) => {
   const openPlayer = () => {
+    // Use the first matching song for this player.
+    // Multiple song records can exist, but only the first is used when
+    // opening the player view.
     let globalIndex = playerSongs.findIndex(
       (song) =>
         song.playerName === player.playerName && song.team === selectedTeam,

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -22,6 +22,8 @@ const PlayerTab = ({
   if (playSource === 'lineup' && currentLineup[currentLineupIndex]) {
     const todayLineupPlayer = currentLineup[currentLineupIndex];
 
+    // Grab the first song record for the lineup player. The dataset may contain
+    // multiple songs for the same player; only the first one is used here.
     let matchedSong = playerSongs.find(
       (song) =>
         song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam


### PR DESCRIPTION
## Summary
- document that only the first matching song is used
- clarify first-song behaviour in the player components and main logic
- mention sorting keeps duplicates

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ddc9bcac83319d7694343e1230df