### PR TITLE
Support multiple songs per player

### DIFF
--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -1,6 +1,6 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import YouTube from 'react-youtube';
-import { Music, SkipBack, SkipForward, Share2, Plus, Mail } from 'lucide-react';
+import { Music, SkipBack, SkipForward } from 'lucide-react';
 import { getTeamInfo, getPositionKorean, getBattingOrder } from '../utils/team';
 import { logRequest } from '../utils/logging';
 import LyricsSection from './LyricsSection';
@@ -13,36 +13,47 @@ const PlayerTab = ({
   selectedTeam,
   playPrev,
   playNext,
-  handleShare,
 }) => {
   const playerRef = useRef(null);
+  const [songIndex, setSongIndex] = useState(0);
+  useEffect(() => {
+    setSongIndex(0);
+  }, [currentPlayer, currentLineupIndex]);
+
   let currentChant = {};
   let hasPlayerData = true;
+  let matches = [];
 
   if (playSource === 'lineup' && currentLineup[currentLineupIndex]) {
     const todayLineupPlayer = currentLineup[currentLineupIndex];
 
-    let matchedSong = playerSongs.find(
+    matches = playerSongs.filter(
       (song) =>
-        song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam
+        song.playerName === todayLineupPlayer.playerName &&
+        song.team === selectedTeam
     );
-    if (!matchedSong) {
-      matchedSong = playerSongs.find(
+    if (matches.length === 0) {
+      matches = playerSongs.filter(
         (song) => song.playerName === todayLineupPlayer.playerName
       );
-      if (matchedSong) {
+      if (matches.length > 0) {
         console.warn(
           `팀 매칭 실패, 선수이름 기반 응원가 사용: ${todayLineupPlayer.playerName} (${selectedTeam})`
         );
       }
     }
 
-    hasPlayerData = !!matchedSong;
-    currentChant = { ...(matchedSong || {}), playerName: todayLineupPlayer.playerName };
+    hasPlayerData = matches.length > 0;
+    const currentSong = matches[songIndex] || {};
+    currentChant = { ...currentSong, playerName: todayLineupPlayer.playerName };
     currentChant.order = todayLineupPlayer.order;
     currentChant.position = todayLineupPlayer.position;
   } else {
-    currentChant = { ...playerSongs[currentPlayer] } || {};
+    matches = playerSongs.filter(
+      (song) => song.playerName === playerSongs[currentPlayer]?.playerName
+    );
+    const currentSong = matches[songIndex] || playerSongs[currentPlayer] || {};
+    currentChant = { ...currentSong };
   }
   const getDisplayTeam = () => {
     const baseTeam =
@@ -96,6 +107,19 @@ const PlayerTab = ({
           <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3">
             {currentChant.playerName}
           </h2>
+          {matches.length > 1 && (
+            <div className="flex gap-2 mb-3">
+              {matches.map((m, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => setSongIndex(idx)}
+                  className={`px-2 py-1 rounded text-sm ${idx === songIndex ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700'}`}
+                >
+                  {m.type || m.chantTitle}
+                </button>
+              ))}
+            </div>
+          )}
           {!hasPlayerData && (
             <div className="mt-2 text-center space-y-1">
               <p className="text-sm text-gray-500">

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -137,20 +137,21 @@ const useKboData = () => {
       setRawSongs(Array.isArray(songsData) ? songsData : []);
 
       // 선수 응원가 데이터 처리 - KBO 선수 기준으로 구성
-      const parsedSongsRaw = parsedKboPlayers.map((player) => {
+      const parsedSongsRaw = [];
+      parsedKboPlayers.forEach((player) => {
         const teamName = normalizeTeamName(player.teamName);
-        let matchedSong = null;
+        let matchedSongs = [];
         if (Array.isArray(songsData)) {
-          matchedSong = songsData.find(
+          matchedSongs = songsData.filter(
             (song) =>
               normalizeTeamName(song.team) === teamName &&
               song.playerName === player.playerName
           );
-          if (!matchedSong) {
-            matchedSong = songsData.find(
+          if (matchedSongs.length === 0) {
+            matchedSongs = songsData.filter(
               (song) => song.playerName === player.playerName
             );
-            if (matchedSong) {
+            if (matchedSongs.length > 0) {
               console.warn(
                 `팀 매칭 실패, 선수이름 기반 응원가 사용: ${player.playerName} (${teamName})`
               );
@@ -158,39 +159,42 @@ const useKboData = () => {
           }
         }
 
-        return {
-          id: `${teamName}_${player.playerName}`,
-          playerId: player.playerId || '',
-          playerName: player.playerName,
-          team: teamName,
-          chantTitle: matchedSong?.chantTitle || `${player.playerName} 응원가`,
-          youtubeId: matchedSong?.youtubeId || '',
-          type: matchedSong?.type || '응원가',
-          lyrics: matchedSong?.lyrics || '',
-          position: normalizePosition(player.position || ''),
-          number: player.number || '',
-          throwBat: player.throwBat || '',
-          birth: player.birth || '',
-          body: player.body || '',
-          teamCode: player.teamCode || '',
-          originalTeam: player.teamName,
-          likes: Math.floor(Math.random() * 2000) + 500,
-          views: Math.floor(Math.random() * 30000) + 5000,
-          rating: (Math.random() * 1 + 4).toFixed(1),
-          comments: Math.floor(Math.random() * 200) + 20,
-          tags: ['신나는', '쉬운', '인기'],
-          addedDate: new Date().toISOString().split('T')[0],
-        };
+        if (matchedSongs.length === 0) {
+          matchedSongs = [{}];
+        }
+
+        matchedSongs.forEach((song, idx) => {
+          const type = song.type || '응원가';
+          const id = song.type
+            ? `${teamName}_${player.playerName}_${song.type}`
+            : `${teamName}_${player.playerName}_${idx}`;
+          parsedSongsRaw.push({
+            id,
+            playerId: player.playerId || '',
+            playerName: player.playerName,
+            team: teamName,
+            chantTitle: song.chantTitle || `${player.playerName} 응원가`,
+            youtubeId: song.youtubeId || '',
+            type: type,
+            lyrics: song.lyrics || '',
+            position: normalizePosition(player.position || ''),
+            number: player.number || '',
+            throwBat: player.throwBat || '',
+            birth: player.birth || '',
+            body: player.body || '',
+            teamCode: player.teamCode || '',
+            originalTeam: player.teamName,
+            likes: Math.floor(Math.random() * 2000) + 500,
+            views: Math.floor(Math.random() * 30000) + 5000,
+            rating: (Math.random() * 1 + 4).toFixed(1),
+            comments: Math.floor(Math.random() * 200) + 20,
+            tags: ['신나는', '쉬운', '인기'],
+            addedDate: new Date().toISOString().split('T')[0],
+          });
+        });
       });
 
-      // 중복 제거 (팀+선수 기준)
-      const uniqueSongMap = new Map();
-      parsedSongsRaw.forEach((song) => {
-        if (!uniqueSongMap.has(song.id)) {
-          uniqueSongMap.set(song.id, song);
-        }
-      });
-      const parsedSongs = Array.from(uniqueSongMap.values());
+      const parsedSongs = parsedSongsRaw;
 
       // 이미 등록된 선수 이름 집합 생성
       const existingPlayerNames = new Set(
@@ -199,14 +203,14 @@ const useKboData = () => {
 
       // 로스터에 없는 선수 응원가 추가
       if (Array.isArray(songsData)) {
-        songsData.forEach((song) => {
+        songsData.forEach((song, index) => {
           if (!existingPlayerNames.has(song.playerName)) {
             const teamName = normalizeTeamName(song.team || '');
             console.warn(
               `로스터 미등록 선수 응원가 추가: ${song.playerName} (${teamName})`
             );
             parsedSongs.push({
-              id: `${teamName}_${song.playerName}`,
+              id: `${teamName}_${song.playerName}_${song.type || index}`,
               playerId: '',
               playerName: song.playerName,
               team: teamName,


### PR DESCRIPTION
## Summary
- allow multiple songs per player in PlayerTab
- show buttons to switch songs when a player has multiple chants
- reset selected song on player change
- remove unused props
- sync data parsing hook with main branch

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ddc85b648331804e5b29f9ef1bb9