### PR TITLE
Display all player songs in single card

### DIFF
--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import ChantCard from './ChantCard';
+import PlayerSongsCard from './PlayerSongsCard';
 import { getTeamInfo } from '../utils/team';
 const ExploreTab = ({
   searchQuery,
@@ -175,18 +176,31 @@ const ExploreTab = ({
           </div>
         </div>
       )}
-      {filteredChants.map((chant) => (
-        <ChantCard
-          key={chant.id}
-          chant={chant}
-          playerSongs={playerSongs}
-          setCurrentPlayer={setCurrentPlayer}
-          setPlaySource={setPlaySource}
-          setShowPlayer={setShowPlayer}
-          handleShare={handleShare}
-          setCurrentPlayerName={setCurrentPlayerName}
-        />
-      ))}
+      {/* 그룹화된 선수 응원가 카드 */}
+      {(() => {
+        const groups = [];
+        const map = {};
+        filteredChants.forEach((chant) => {
+          if (map[chant.playerName]) {
+            map[chant.playerName].push(chant);
+          } else {
+            map[chant.playerName] = [chant];
+            groups.push(map[chant.playerName]);
+          }
+        });
+        return groups.map((chants) => (
+          <PlayerSongsCard
+            key={chants[0].id}
+            chants={chants}
+            playerSongs={playerSongs}
+            setCurrentPlayer={setCurrentPlayer}
+            setPlaySource={setPlaySource}
+            setShowPlayer={setShowPlayer}
+            handleShare={handleShare}
+            setCurrentPlayerName={setCurrentPlayerName}
+          />
+        ));
+      })()}
       {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체') && !isComposing && (
         <div className="text-center py-8 text-gray-500">
           <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Play, Share2 } from 'lucide-react';
+import { getTeamInfo, getPositionKorean } from '../utils/team';
+
+const PlayerSongsCard = ({
+  chants,
+  playerSongs,
+  setCurrentPlayer,
+  setPlaySource,
+  setShowPlayer,
+  handleShare,
+  setCurrentPlayerName,
+}) => {
+  const openPlayer = (chant) => {
+    const idx = playerSongs.findIndex((c) => c.id === chant.id);
+    if (idx !== -1) {
+      setCurrentPlayer(idx);
+      setPlaySource('explore');
+      setCurrentPlayerName(chant.playerName);
+      setShowPlayer(true);
+    }
+  };
+
+  if (!chants || chants.length === 0) return null;
+  const first = chants[0];
+
+  return (
+    <div className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 space-y-3">
+      <div className="flex-1">
+        <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{first.playerName}</h3>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mt-1">
+          <div className="flex items-center gap-1">
+            {getTeamInfo(first.team).logo && (
+              <img
+                src={getTeamInfo(first.team).logo}
+                alt={first.team}
+                className="w-4 h-4 object-contain"
+              />
+            )}
+            <span
+              className="font-medium px-2 py-1 rounded-full text-xs"
+              style={{
+                backgroundColor: `${getTeamInfo(first.team).color}15`,
+                color: getTeamInfo(first.team).color,
+              }}
+            >
+              {first.team}
+            </span>
+          </div>
+          {first.position && (
+            <>
+              <span className="text-gray-300">•</span>
+              <span className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full text-xs">
+                {getPositionKorean(first.position)}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {chants.map((chant) => (
+          <div key={chant.id} className="flex items-center gap-2">
+            <button
+              className="flex-1 bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-2 px-3 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
+              onClick={() => openPlayer(chant)}
+            >
+              <Play className="w-4 h-4" />
+              {chant.chantTitle}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleShare(chant);
+              }}
+              className="p-2 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
+            >
+              <Share2 className="w-4 h-4 text-gray-600" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PlayerSongsCard;


### PR DESCRIPTION
## Summary
- group songs by player in `ExploreTab`
- add `PlayerSongsCard` component to show multiple chants for a player on one card

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e2fb13348331a9752cea12a03afa