### PR TITLE
Fix past game status

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -109,7 +109,22 @@ const LineupTab = ({
                   {currentGame.location ||
                     getTeamInfo(currentGame.home).stadium}{' '}
                   • {formatDateKorean(currentGame.date)}
-                  {currentGame.gameStatus && ` • ${currentGame.gameStatus}`}
+                  {(() => {
+                    const isCanceled =
+                      currentGame.canceled ||
+                      (currentGame.gameStatus && currentGame.gameStatus.includes('취소'));
+                    const gameDate = new Date(currentGame.date);
+                    const nextDay = new Date(gameDate);
+                    nextDay.setDate(gameDate.getDate() + 1);
+                    nextDay.setHours(0, 0, 0, 0);
+                    const isPast = new Date() >= nextDay;
+
+                    let status = currentGame.gameStatus || '';
+                    if (!isCanceled && isPast) {
+                      status = '종료';
+                    }
+                    return status ? ` • ${status}` : '';
+                  })()}
                 </p>
               </div>
             </div>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -52,15 +52,28 @@ const ScheduleTab = ({
           </button>
         ))}
       </div>
-      {filteredSchedules.map((game) => {
-        const isCanceled =
-          game.canceled || (game.gameStatus && game.gameStatus.includes('취소'));
-        return (
-          <div
-            key={game.id}
-            onClick={() => { if (setSelectedDate) setSelectedDate(game.date); if (setActiveTab) setActiveTab("lineup"); }}
-            className={`cursor-pointer flex items-center justify-between rounded-lg p-3 shadow ${
-              isCanceled
+        {filteredSchedules.map((game) => {
+          const isCanceled =
+            game.canceled || (game.gameStatus && game.gameStatus.includes('취소'));
+
+          // Determine if the game date has passed (00:00 of the next day)
+          const gameDate = new Date(game.date);
+          const nextDay = new Date(gameDate);
+          nextDay.setDate(gameDate.getDate() + 1);
+          nextDay.setHours(0, 0, 0, 0);
+          const isPast = new Date() >= nextDay;
+
+          let displayStatus = game.gameStatus || '';
+          if (!isCanceled && isPast) {
+            displayStatus = '종료';
+          }
+
+          return (
+            <div
+              key={game.id}
+              onClick={() => { if (setSelectedDate) setSelectedDate(game.date); if (setActiveTab) setActiveTab("lineup"); }}
+              className={`cursor-pointer flex items-center justify-between rounded-lg p-3 shadow ${
+                isCanceled
                 ? 'bg-gray-100 dark:bg-gray-800 text-gray-500 line-through'
                 : 'bg-white dark:bg-gray-700'
             }`}
@@ -87,18 +100,18 @@ const ScheduleTab = ({
               <span className="text-xs text-gray-500">(홈)</span>
             </div>
             <div className="text-sm text-right text-gray-600 dark:text-gray-300">
-              <div>
-                {game.gameTime || '미정'} •{' '}
-                {game.location || getTeamInfo(game.home).stadium}
-              </div>
-              <div>
-                {formatDateKorean(game.date)}
-                {game.gameStatus ? ` • ${game.gameStatus}` : ''}
+                <div>
+                  {game.gameTime || '미정'} •{' '}
+                  {game.location || getTeamInfo(game.home).stadium}
+                </div>
+                <div>
+                  {formatDateKorean(game.date)}
+                  {displayStatus ? ` • ${displayStatus}` : ''}
+                </div>
               </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show games as finished the day after they were scheduled
- display the same status in lineup details

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e478e430833190800c8b32cc26fe