### PR TITLE
Filter staff without songs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -543,11 +543,17 @@ const getSortedChants = () => {
       return false;
     }
 
-    if (hasBatterOnly && getPositionKorean(chant.position) === '투수') {
+    const posKor = getPositionKorean(chant.position);
+
+    if (hasBatterOnly && posKor === '투수') {
       return false;
     }
 
     if (hasSongOnly && !chant.youtubeId) {
+      return false;
+    }
+
+    if (['코치', '감독', '투수'].includes(posKor) && !chant.youtubeId) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- ignore coaches, managers, and pitchers who have no chant video

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eaca1efc8331af125fa6f142c406