### PR TITLE
Implement collapsible player cards

### DIFF
--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Play, Share2 } from 'lucide-react';
 import { getTeamInfo, getPositionKorean } from '../utils/team';
 
 const PlayerSongsCard = ({
@@ -8,76 +7,56 @@ const PlayerSongsCard = ({
   setCurrentPlayer,
   setPlaySource,
   setShowPlayer,
-  handleShare,
   setCurrentPlayerName,
 }) => {
-  const openPlayer = (chant) => {
-    const idx = playerSongs.findIndex((c) => c.id === chant.id);
-    if (idx !== -1) {
-      setCurrentPlayer(idx);
-      setPlaySource('explore');
-      setCurrentPlayerName(chant.playerName);
-      setShowPlayer(true);
-    }
+  const openPlayer = () => {
+    if (!chants || chants.length === 0) return;
+    const first = chants[0];
+    const idx = playerSongs.findIndex(
+      (c) => c.playerName === first.playerName && c.team === first.team
+    );
+    setCurrentPlayer(idx !== -1 ? idx : 0);
+    setPlaySource('explore');
+    setCurrentPlayerName(first.playerName);
+    setShowPlayer(true);
   };
 
   if (!chants || chants.length === 0) return null;
   const first = chants[0];
 
   return (
-    <div className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 space-y-3">
-      <div className="flex-1">
-        <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{first.playerName}</h3>
-        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mt-1">
-          <div className="flex items-center gap-1">
-            {getTeamInfo(first.team).logo && (
-              <img
-                src={getTeamInfo(first.team).logo}
-                alt={first.team}
-                className="w-4 h-4 object-contain"
-              />
-            )}
-            <span
-              className="font-medium px-2 py-1 rounded-full text-xs"
-              style={{
-                backgroundColor: `${getTeamInfo(first.team).color}15`,
-                color: getTeamInfo(first.team).color,
-              }}
-            >
-              {first.team}
-            </span>
-          </div>
-          {first.position && (
-            <>
-              <span className="text-gray-300">•</span>
-              <span className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full text-xs">
-                {getPositionKorean(first.position)}
-              </span>
-            </>
+    <div
+      className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
+      onClick={openPlayer}
+    >
+      <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">{first.playerName}</h3>
+      <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mt-1">
+        <div className="flex items-center gap-1">
+          {getTeamInfo(first.team).logo && (
+            <img
+              src={getTeamInfo(first.team).logo}
+              alt={first.team}
+              className="w-4 h-4 object-contain"
+            />
           )}
+          <span
+            className="font-medium px-2 py-1 rounded-full text-xs"
+            style={{
+              backgroundColor: `${getTeamInfo(first.team).color}15`,
+              color: getTeamInfo(first.team).color,
+            }}
+          >
+            {first.team}
+          </span>
         </div>
-      </div>
-      <div className="space-y-2">
-        {chants.map((chant) => (
-          <div key={chant.id} className="flex items-center gap-2">
-            <button
-              className="flex-1 bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-2 px-3 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
-              onClick={() => openPlayer(chant)}
-            >
-              <Play className="w-4 h-4" />
-              {chant.chantTitle}
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                handleShare(chant);
-              }}
-              className="p-2 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
-            >
-              <Share2 className="w-4 h-4 text-gray-600" />
-            </button>
-          </div>
-        ))}
+        {first.position && (
+          <>
+            <span className="text-gray-300">•</span>
+            <span className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full text-xs">
+              {getPositionKorean(first.position)}
+            </span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import YouTube from 'react-youtube';
 import { Music, SkipBack, SkipForward, Share2, Plus, Mail } from 'lucide-react';
 import { getTeamInfo, getPositionKorean, getBattingOrder } from '../utils/team';
@@ -16,36 +16,46 @@ const PlayerTab = ({
   handleShare,
 }) => {
   const playerRef = useRef(null);
-  let currentChant = {};
-  let hasPlayerData = true;
+  const [songIndex, setSongIndex] = useState(0);
+  useEffect(() => {
+    setSongIndex(0);
+  }, [currentPlayer, currentLineupIndex, playSource, selectedTeam]);
+  let songsForPlayer = [];
+  let baseInfo = { playerName: '', order: '', position: '' };
 
   if (playSource === 'lineup' && currentLineup[currentLineupIndex]) {
-    const todayLineupPlayer = currentLineup[currentLineupIndex];
-
-    // Grab the first song record for the lineup player. The dataset may contain
-    // multiple songs for the same player; only the first one is used here.
-    let matchedSong = playerSongs.find(
-      (song) =>
-        song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam
+    const lineupPlayer = currentLineup[currentLineupIndex];
+    baseInfo = {
+      playerName: lineupPlayer.playerName,
+      order: lineupPlayer.order,
+      position: lineupPlayer.position,
+    };
+    songsForPlayer = playerSongs.filter(
+      (s) => s.playerName === lineupPlayer.playerName && s.team === selectedTeam
     );
-    if (!matchedSong) {
-      matchedSong = playerSongs.find(
-        (song) => song.playerName === todayLineupPlayer.playerName
-      );
-      if (matchedSong) {
-        console.warn(
-          `팀 매칭 실패, 선수이름 기반 응원가 사용: ${todayLineupPlayer.playerName} (${selectedTeam})`
-        );
-      }
+    if (songsForPlayer.length === 0) {
+      songsForPlayer = playerSongs.filter((s) => s.playerName === lineupPlayer.playerName);
     }
-
-    hasPlayerData = !!matchedSong;
-    currentChant = { ...(matchedSong || {}), playerName: todayLineupPlayer.playerName };
-    currentChant.order = todayLineupPlayer.order;
-    currentChant.position = todayLineupPlayer.position;
   } else {
-    currentChant = { ...playerSongs[currentPlayer] } || {};
+    const baseSong = playerSongs[currentPlayer] || {};
+    baseInfo = {
+      playerName: baseSong.playerName,
+      order: baseSong.order,
+      position: baseSong.position,
+    };
+    songsForPlayer = playerSongs.filter(
+      (s) => s.playerName === baseSong.playerName && s.team === (baseSong.team || selectedTeam)
+    );
+    if (songsForPlayer.length === 0) {
+      songsForPlayer = playerSongs.filter((s) => s.playerName === baseSong.playerName);
+    }
   }
+
+  const hasPlayerData = songsForPlayer.length > 0;
+  const currentChant =
+    songsForPlayer[songIndex] || { playerName: baseInfo.playerName };
+  currentChant.order = baseInfo.order;
+  currentChant.position = baseInfo.position;
   const getDisplayTeam = () => {
     const baseTeam =
       playSource === 'lineup'
@@ -161,6 +171,23 @@ const PlayerTab = ({
           )}
         </div>
       </div>
+      {songsForPlayer.length > 1 && (
+        <div className="flex gap-2 py-2">
+          {songsForPlayer.map((song, idx) => (
+            <button
+              key={idx}
+              onClick={() => setSongIndex(idx)}
+              className={`px-3 py-1 rounded-full text-xs ${
+                idx === songIndex
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+              }`}
+            >
+              {song.type || `응원가${idx + 1}`}
+            </button>
+          ))}
+        </div>
+      )}
       {/* 컨트롤 버튼 */}
       <div className="flex items-center justify-between gap-2 py-2">
         <button


### PR DESCRIPTION
## Summary
- add song selector tabs in PlayerTab
- simplify PlayerSongsCard to open the detail view

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eb0180ec8331805aa509784fff78