### PR TITLE
Add song selector tabs

### DIFF
--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Play, Share2, ChevronDown, ChevronUp } from 'lucide-react';
+import React from 'react';
+import { Play, Share2 } from 'lucide-react';
 import { getTeamInfo, getPositionKorean } from '../utils/team';
 
 const PlayerSongsCard = ({
@@ -11,24 +11,25 @@ const PlayerSongsCard = ({
   handleShare,
   setCurrentPlayerName,
 }) => {
-  const [expanded, setExpanded] = useState(false);
-  const openPlayer = (chant) => {
-    const idx = playerSongs.findIndex((c) => c.id === chant.id);
+  if (!chants || chants.length === 0) return null;
+  const first = chants[0];
+
+  const openPlayer = () => {
+    const idx = playerSongs.findIndex(
+      (c) => c.playerName === first.playerName && c.team === first.team
+    );
     if (idx !== -1) {
       setCurrentPlayer(idx);
       setPlaySource('explore');
-      setCurrentPlayerName(chant.playerName);
+      setCurrentPlayerName(first.playerName);
       setShowPlayer(true);
     }
   };
 
-  if (!chants || chants.length === 0) return null;
-  const first = chants[0];
-
   return (
     <div
       className="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 space-y-3 cursor-pointer"
-      onClick={() => setExpanded(!expanded)}
+      onClick={openPlayer}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1">
@@ -63,40 +64,27 @@ const PlayerSongsCard = ({
           </div>
         </div>
         <div className="flex-shrink-0 mt-1">
-          {expanded ? (
-            <ChevronUp className="w-5 h-5 text-gray-500" />
-          ) : (
-            <ChevronDown className="w-5 h-5 text-gray-500" />
-          )}
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleShare(first);
+            }}
+            className="p-2 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
+          >
+            <Share2 className="w-4 h-4 text-gray-600" />
+          </button>
         </div>
       </div>
-      {expanded && (
-        <div className="space-y-2">
-          {chants.map((chant) => (
-            <div key={chant.id} className="flex items-center gap-2">
-              <button
-                className="flex-1 bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-2 px-3 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openPlayer(chant);
-                }}
-              >
-                <Play className="w-4 h-4" />
-                {chant.chantTitle}
-              </button>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleShare(chant);
-                }}
-                className="p-2 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
-              >
-                <Share2 className="w-4 h-4 text-gray-600" />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
+      <button
+        className="w-full bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-2 px-3 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
+        onClick={(e) => {
+          e.stopPropagation();
+          openPlayer();
+        }}
+      >
+        <Play className="w-4 h-4" />
+        {first.chantTitle}
+      </button>
     </div>
   );
 };

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import YouTube from 'react-youtube';
 import { Music, SkipBack, SkipForward, Share2, Plus, Mail } from 'lucide-react';
 import { getTeamInfo, getPositionKorean, getBattingOrder } from '../utils/team';
@@ -16,35 +16,53 @@ const PlayerTab = ({
   handleShare,
 }) => {
   const playerRef = useRef(null);
+  const [songIndex, setSongIndex] = useState(0);
   let currentChant = {};
   let hasPlayerData = true;
+
+  useEffect(() => {
+    setSongIndex(0);
+  }, [currentPlayer, currentLineupIndex, playSource]);
+
+  let songsForPlayer = [];
 
   if (playSource === 'lineup' && currentLineup[currentLineupIndex]) {
     const todayLineupPlayer = currentLineup[currentLineupIndex];
 
-    // Grab the first song record for the lineup player. The dataset may contain
-    // multiple songs for the same player; only the first one is used here.
-    let matchedSong = playerSongs.find(
+    songsForPlayer = playerSongs.filter(
       (song) =>
         song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam
     );
-    if (!matchedSong) {
-      matchedSong = playerSongs.find(
+    if (songsForPlayer.length === 0) {
+      songsForPlayer = playerSongs.filter(
         (song) => song.playerName === todayLineupPlayer.playerName
       );
-      if (matchedSong) {
+      if (songsForPlayer.length > 0) {
         console.warn(
           `팀 매칭 실패, 선수이름 기반 응원가 사용: ${todayLineupPlayer.playerName} (${selectedTeam})`
         );
       }
     }
 
-    hasPlayerData = !!matchedSong;
-    currentChant = { ...(matchedSong || {}), playerName: todayLineupPlayer.playerName };
+    hasPlayerData = songsForPlayer.length > 0;
+    const baseSong = songsForPlayer[songIndex] || songsForPlayer[0] || {};
+    currentChant = { ...baseSong, playerName: todayLineupPlayer.playerName };
     currentChant.order = todayLineupPlayer.order;
     currentChant.position = todayLineupPlayer.position;
   } else {
-    currentChant = { ...playerSongs[currentPlayer] } || {};
+    const baseSong = playerSongs[currentPlayer] || {};
+    songsForPlayer = playerSongs.filter(
+      (song) =>
+        song.playerName === baseSong.playerName && song.team === baseSong.team
+    );
+    if (songsForPlayer.length === 0) {
+      songsForPlayer = playerSongs.filter(
+        (song) => song.playerName === baseSong.playerName
+      );
+    }
+    hasPlayerData = songsForPlayer.length > 0;
+    const songToUse = songsForPlayer[songIndex] || baseSong;
+    currentChant = { ...songToUse };
   }
   const getDisplayTeam = () => {
     const baseTeam =
@@ -161,6 +179,23 @@ const PlayerTab = ({
           )}
         </div>
       </div>
+      {songsForPlayer.length > 1 && (
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">
+          {songsForPlayer.map((song, idx) => (
+            <button
+              key={song.id}
+              onClick={() => setSongIndex(idx)}
+              className={`px-3 py-1 rounded-full text-sm whitespace-nowrap ${
+                songIndex === idx
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200'
+              }`}
+            >
+              {song.chantTitle}
+            </button>
+          ))}
+        </div>
+      )}
       {/* 컨트롤 버튼 */}
       <div className="flex items-center justify-between gap-2 py-2">
         <button


### PR DESCRIPTION
## Summary
- show a share button on PlayerSongsCard and remove expand UI
- introduce song selection tabs inside PlayerTab
- reset selected song when player changes

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645b54c5748331954066220f75afbe