### PR TITLE
Fix player filter to include pitchers without chants

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -553,7 +553,7 @@ const getSortedChants = () => {
       return false;
     }
 
-    if (['코치', '감독', '투수'].includes(posKor) && !chant.youtubeId) {
+    if (['코치', '감독'].includes(posKor) && !chant.youtubeId) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- update filtering so pitchers still show up even if they don't have a chant

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864685e0fcc8331a0f08ef4c80960e5