### PR TITLE
Fix lineup song selection for duplicate player names

### DIFF
--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -23,13 +23,17 @@ const PlayerCard = ({
     );
 
     if (globalIndex === -1) {
-      globalIndex = playerSongs.findIndex(
-        (song) => song.playerName === player.playerName,
+      const nameMatches = playerSongs.filter(
+        (song) => song.playerName === player.playerName
       );
-      if (globalIndex !== -1) {
-        console.warn(
-          `팀 매칭 실패, 선수이름 기반 응원가 사용: ${player.playerName} (${selectedTeam})`
-        );
+      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
+      if (nameMatches.length === 1 || uniqueTeams.length === 1) {
+        globalIndex = playerSongs.indexOf(nameMatches[0]);
+        if (globalIndex !== -1) {
+          console.warn(
+            `팀 매칭 실패, 선수이름 기반 응원가 사용: ${player.playerName} (${selectedTeam})`
+          );
+        }
       }
     }
 

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -34,10 +34,12 @@ const PlayerTab = ({
         song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam
     );
     if (songsForPlayer.length === 0) {
-      songsForPlayer = playerSongs.filter(
+      const nameMatches = playerSongs.filter(
         (song) => song.playerName === todayLineupPlayer.playerName
       );
-      if (songsForPlayer.length > 0) {
+      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
+      if (nameMatches.length > 0 && uniqueTeams.length === 1) {
+        songsForPlayer = nameMatches;
         console.warn(
           `팀 매칭 실패, 선수이름 기반 응원가 사용: ${todayLineupPlayer.playerName} (${selectedTeam})`
         );
@@ -56,9 +58,13 @@ const PlayerTab = ({
         song.playerName === baseSong.playerName && song.team === baseSong.team
     );
     if (songsForPlayer.length === 0) {
-      songsForPlayer = playerSongs.filter(
+      const nameMatches = playerSongs.filter(
         (song) => song.playerName === baseSong.playerName
       );
+      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
+      if (nameMatches.length > 0 && uniqueTeams.length === 1) {
+        songsForPlayer = nameMatches;
+      }
     }
     hasPlayerData = songsForPlayer.length > 0;
     const songToUse = songsForPlayer[songIndex] || baseSong;


### PR DESCRIPTION
## Summary
- disambiguate players with identical names across teams
- fall back to name-only match only if player name is unique across teams

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686721c3d6b48331ba6eb139172a6797