### PR TITLE
Fix player cheer lookup

### DIFF
--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -21,22 +21,6 @@ const PlayerCard = ({
       (song) =>
         song.playerName === player.playerName && song.team === selectedTeam,
     );
-
-    if (globalIndex === -1) {
-      const nameMatches = playerSongs.filter(
-        (song) => song.playerName === player.playerName
-      );
-      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
-      if (nameMatches.length === 1 || uniqueTeams.length === 1) {
-        globalIndex = playerSongs.indexOf(nameMatches[0]);
-        if (globalIndex !== -1) {
-          console.warn(
-            `팀 매칭 실패, 선수이름 기반 응원가 사용: ${player.playerName} (${selectedTeam})`
-          );
-        }
-      }
-    }
-
     if (globalIndex !== -1) {
       setCurrentPlayer(globalIndex);
     } else {

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -33,18 +33,6 @@ const PlayerTab = ({
       (song) =>
         song.playerName === todayLineupPlayer.playerName && song.team === selectedTeam
     );
-    if (songsForPlayer.length === 0) {
-      const nameMatches = playerSongs.filter(
-        (song) => song.playerName === todayLineupPlayer.playerName
-      );
-      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
-      if (nameMatches.length > 0 && uniqueTeams.length === 1) {
-        songsForPlayer = nameMatches;
-        console.warn(
-          `팀 매칭 실패, 선수이름 기반 응원가 사용: ${todayLineupPlayer.playerName} (${selectedTeam})`
-        );
-      }
-    }
 
     hasPlayerData = songsForPlayer.length > 0;
     const baseSong = songsForPlayer[songIndex] || songsForPlayer[0] || {};
@@ -57,15 +45,6 @@ const PlayerTab = ({
       (song) =>
         song.playerName === baseSong.playerName && song.team === baseSong.team
     );
-    if (songsForPlayer.length === 0) {
-      const nameMatches = playerSongs.filter(
-        (song) => song.playerName === baseSong.playerName
-      );
-      const uniqueTeams = [...new Set(nameMatches.map((s) => s.team))];
-      if (nameMatches.length > 0 && uniqueTeams.length === 1) {
-        songsForPlayer = nameMatches;
-      }
-    }
     hasPlayerData = songsForPlayer.length > 0;
     const songToUse = songsForPlayer[songIndex] || baseSong;
     currentChant = { ...songToUse };

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -147,16 +147,6 @@ const useKboData = () => {
               normalizeTeamName(song.team) === teamName &&
               song.playerName === player.playerName
           );
-          if (matchedSongs.length === 0) {
-            matchedSongs = songsData.filter(
-              (song) => song.playerName === player.playerName
-            );
-            if (matchedSongs.length > 0) {
-              console.warn(
-                `팀 매칭 실패, 선수이름 기반 응원가 사용: ${player.playerName} (${teamName})`
-              );
-            }
-          }
         }
 
         if (matchedSongs.length === 0) {


### PR DESCRIPTION
## Summary
- ensure team matches when finding player songs
- simplify lineup song lookup logic

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672518df80833187a8ae3372369883