### PR TITLE
Fix explore tab default filter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,10 +74,11 @@ const JikgwanGaja = () => {
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
 
-  // Ensure explore tab reflects the globally selected team
+  // Keep explore tab independent of the globally selected team
+  // Default to showing all teams so users can search freely
   useEffect(() => {
-    setExploreTeamFilter(selectedTeam);
-  }, [selectedTeam]);
+    setExploreTeamFilter('전체');
+  }, []);
 
   useEffect(() => {
     setSelectedGameCode(null);


### PR DESCRIPTION
## Summary
- keep the Explore tab team filter independent from the global team
- initialize Explore tab filter to `전체`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674514395c8331a7dc06f77bd79552