### PR TITLE
Add schedule crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Run the crawler:
 python public/kbo_players_crawler.py
 ```
 
+## Crawling schedules
+
+`public/kbo_schedule_crawler.py` reuses the lineup crawler's Selenium logic to
+collect basic game schedule information such as time, status and scores. The
+results are written to `public/data/kboSchedule.json`.
+
+Run it for a specific date range:
+
+```bash
+python public/kbo_schedule_crawler.py --start 2025-03-25 --end 2025-03-30 --output public/data/kboSchedule.json
+```
+
 ## Automated daily crawl
 
 Three GitHub Actions workflows keep the data updated:

--- a/public/kbo_schedule_crawler.py
+++ b/public/kbo_schedule_crawler.py
@@ -1,0 +1,57 @@
+import os
+import json
+from datetime import datetime, timedelta
+import argparse
+
+from kbo_crawler import NaverKBOAllLineupCrawler
+
+
+def fetch_schedule(start_date: str, end_date: str) -> list:
+    """Fetch schedule data between the given dates inclusive."""
+    crawler = NaverKBOAllLineupCrawler()
+    results = []
+    try:
+        start = datetime.strptime(start_date, "%Y-%m-%d")
+        end = datetime.strptime(end_date, "%Y-%m-%d")
+        current = start
+        while current <= end:
+            date_str = current.strftime("%Y-%m-%d")
+            games = crawler.get_daily_games(date_str)
+            results.extend(games)
+            current += timedelta(days=1)
+    finally:
+        crawler.close()
+    return results
+
+
+def save_schedule(schedule: list, path: str = "public/data/kboSchedule.json") -> None:
+    """Save schedule list to JSON with a crawl timestamp."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    data = {
+        "crawl_time": datetime.now().isoformat(),
+        "results": schedule,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="KBO schedule crawler")
+    parser.add_argument("--start", type=str, required=False,
+                        default=datetime.now().strftime("%Y-%m-%d"),
+                        help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", type=str, required=False,
+                        default=datetime.now().strftime("%Y-%m-%d"),
+                        help="End date YYYY-MM-DD")
+    parser.add_argument("--output", type=str,
+                        default="public/data/kboSchedule.json",
+                        help="Output JSON path")
+    args = parser.parse_args()
+
+    schedule = fetch_schedule(args.start, args.end)
+    save_schedule(schedule, args.output)
+    print(f"Saved {len(schedule)} games to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape schedules using kbo_schedule_crawler.py
- document how to crawl schedules

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686756054d708331aee1164fe8b0b92f