### PR TITLE
Add schedule crawler workflow

### DIFF
--- a/.github/workflows/schedule-crawl.yml
+++ b/.github/workflows/schedule-crawl.yml
@@ -1,0 +1,50 @@
+name: Daily KBO schedule crawl
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests beautifulsoup4 pandas selenium webdriver-manager
+
+      - name: Install Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+
+      - name: Run schedule crawler
+        run: |
+          export DISPLAY=:99
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          python public/kbo_schedule_crawler.py
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/kboSchedule.json
+          git commit -m "Daily schedule update" || echo "No changes to commit"
+          git pull --rebase origin main
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ python public/kbo_players_crawler.py
 
 ## Automated daily crawl
 
-Three GitHub Actions workflows keep the data updated:
+Four GitHub Actions workflows keep the data updated:
 
 - `.github/workflows/lineup-crawl.yml` fetches new lineups several times each day and rebuilds `public/data/kbo_crawler_data/index.json`.
 - `.github/workflows/player-crawl.yml` updates `public/data/kboPlayers.json` daily at 00:00 UTC.
 - `.github/workflows/team-rank-crawl.yml` refreshes `public/data/teamRank.json` once per day.
+- `.github/workflows/schedule-crawl.yml` updates `public/data/kboSchedule.json` once per day.
 
 All workflows commit any changes back to the repository automatically.
 


### PR DESCRIPTION
## Summary
- automate schedule crawling with `schedule-crawl.yml`
- mention the new workflow in the README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675609b3688331a26915991e674354