### PR TITLE
Add ranking tab and schedule modal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,8 @@ import { getTeamInfo, getPositionKorean, getBattingOrder } from './utils/team';
 import PlayerTab from './components/PlayerTab';
 import ExploreTab from './components/ExploreTab';
 import TeamChantsTab from './components/TeamChantsTab';
-import ScheduleTab from './components/ScheduleTab';
+import ScheduleTab from './components/ScheduleTab'; // for modal
+import RankingTab from './components/RankingTab';
 import CalendarDropdown from './components/CalendarDropdown';
 import TeamDropdown from './components/TeamDropdown';
 import useKboData from './hooks/useKboData';
@@ -74,6 +75,7 @@ const JikgwanGaja = () => {
   const [selectedGameCode, setSelectedGameCode] = useState(null);
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
+  const [showScheduleModal, setShowScheduleModal] = useState(false);
 
   // Keep explore tab independent of the globally selected team
   // Default to showing all teams so users can search freely
@@ -106,7 +108,7 @@ const JikgwanGaja = () => {
 
     const setTabFromHash = () => {
       const tab = window.location.hash.replace('#', '');
-      if (tab && ['lineup', 'teamChants', 'explore', 'schedule'].includes(tab)) {
+      if (tab && ['lineup', 'teamChants', 'explore', 'ranking'].includes(tab)) {
         setActiveTab(tab);
         setShowPlayer(false);
       }
@@ -188,6 +190,7 @@ const JikgwanGaja = () => {
     loading,
     error,
     fetchJsonData,
+    teamRanks,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -750,6 +753,7 @@ const getSortedChants = () => {
             value={selectedDate}
             onChange={setSelectedDate}
             gameDates={gameDatesForTeam}
+            onOpenSchedule={() => setShowScheduleModal(true)}
           />
           <TeamDropdown value={selectedTeam} onChange={setSelectedTeam} />
         </div>
@@ -801,17 +805,17 @@ const getSortedChants = () => {
         </button>
         <button
           onClick={() => {
-            setActiveTab('schedule');
+            setActiveTab('ranking');
             setShowPlayer(false);
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
-            activeTab === 'schedule' && !showPlayer
+            activeTab === 'ranking' && !showPlayer
               ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
               : 'text-gray-600'
           }`}
         >
-          <Calendar className="w-6 h-6" />
-          <span className="text-xs">일정</span>
+          <Trophy className="w-6 h-6" />
+          <span className="text-xs">순위</span>
         </button>
       </div>
 
@@ -863,6 +867,7 @@ const getSortedChants = () => {
                 gameLineups={gameLineups}
                 setSelectedDate={setSelectedDate}
                 handleShareLineup={handleShareLineup}
+                teamRanks={teamRanks}
               />
             )}
             {activeTab === 'teamChants' && (
@@ -902,20 +907,35 @@ const getSortedChants = () => {
                 setCurrentPlayerName={setCurrentPlayerName}
               />
             )}
-            {activeTab === 'schedule' && (
-              <ScheduleTab
-                selectedTeam={selectedTeam}
-                gameLineups={gameLineups}
-                formatDateKorean={formatDateKorean}
-                setSelectedDate={setSelectedDate}
-                setActiveTab={setActiveTab}
-              />
+            {activeTab === 'ranking' && (
+              <RankingTab teamRanks={teamRanks} />
             )}
           </>
         )}
       </div>
       <Footer />
       <AddToHomePopup />
+      {showScheduleModal && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-black/50 backdrop-blur-sm">
+          <div className="bg-white dark:bg-gray-800 m-4 p-4 rounded-xl flex-1 overflow-y-auto">
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={() => setShowScheduleModal(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                닫기
+              </button>
+            </div>
+            <ScheduleTab
+              selectedTeam={selectedTeam}
+              gameLineups={gameLineups}
+              formatDateKorean={formatDateKorean}
+              setSelectedDate={setSelectedDate}
+              setActiveTab={setActiveTab}
+            />
+          </div>
+        </div>
+      )}
    </div>
  );
 };

--- a/src/components/CalendarDropdown.jsx
+++ b/src/components/CalendarDropdown.jsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 
 const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
 
-const CalendarDropdown = ({ value, onChange, gameDates }) => {
+const CalendarDropdown = ({ value, onChange, gameDates, onOpenSchedule }) => {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState(() => new Date(value));
   const ref = useRef(null);
@@ -114,6 +114,15 @@ const CalendarDropdown = ({ value, onChange, gameDates }) => {
               );
             })}
           </div>
+          <button
+            onClick={() => {
+              if (typeof onOpenSchedule === 'function') onOpenSchedule();
+              setOpen(false);
+            }}
+            className="mt-2 w-full text-sm text-blue-600 hover:text-blue-800"
+          >
+            전체 일정 보기
+          </button>
         </div>
       )}
     </div>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -25,8 +25,13 @@ const LineupTab = ({
   gameLineups,
   setSelectedDate,
   handleShareLineup,
+  teamRanks,
 }) => {
   const currentGame = getCurrentGame();
+  const getRank = (team) => {
+    const r = teamRanks?.find((t) => t.team === team);
+    return r ? `${r.rank}위` : '';
+  };
 
   return (
     <div className="space-y-3">
@@ -93,6 +98,11 @@ const LineupTab = ({
                     />
                   )}
                   <span className="font-semibold">{currentGame.away}</span>
+                  {getRank(currentGame.away) && (
+                    <span className="text-xs text-gray-500 ml-1">(
+                      {getRank(currentGame.away)}
+                    )</span>
+                  )}
                   <span className="text-xs text-gray-500">(원정)</span>
                   <span className="mx-1 text-gray-500">vs</span>
                   {getTeamInfo(currentGame.home).logo && (
@@ -103,6 +113,11 @@ const LineupTab = ({
                     />
                   )}
                   <span className="font-semibold">{currentGame.home}</span>
+                  {getRank(currentGame.home) && (
+                    <span className="text-xs text-gray-500 ml-1">(
+                      {getRank(currentGame.home)}
+                    )</span>
+                  )}
                   <span className="text-xs text-gray-500">(홈)</span>
                 </div>
                 <p className="text-sm text-gray-600 dark:text-gray-300">

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { getTeamInfo } from '../utils/team';
+
+const RankingTab = ({ teamRanks }) => {
+  const sorted = (teamRanks || []).slice().sort((a, b) => parseInt(a.rank) - parseInt(b.rank));
+  return (
+    <div className="space-y-2">
+      {sorted.map((r) => (
+        <div key={r.team} className="flex items-center justify-between bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <div className="flex items-center gap-2">
+            <span className="w-5 text-sm font-bold">{r.rank}</span>
+            {getTeamInfo(r.team).logo && (
+              <img src={getTeamInfo(r.team).logo} alt={r.team} className="w-5 h-5 object-contain" />
+            )}
+            <span className="font-medium">{r.team}</span>
+          </div>
+          <div className="text-sm text-right text-gray-600 dark:text-gray-300">
+            <span>{r.wins}-{r.draws}-{r.losses}</span>
+            <span className="ml-2">{r.win_rate}</span>
+            {r.gb !== undefined && r.gb !== null && (
+              <span className="ml-2 text-xs text-gray-500">GB {r.gb}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RankingTab;

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -97,6 +97,7 @@ const useKboData = () => {
   const [teamChants, setTeamChants] = useState([]);
   const [kboPlayers, setKboPlayers] = useState([]);
   const [rawSongs, setRawSongs] = useState([]);
+  const [teamRanks, setTeamRanks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -117,19 +118,21 @@ const useKboData = () => {
     try {
       const base = process.env.PUBLIC_URL || '';
 
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups] = await Promise.all([
+      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
         fetchSafeJson(`${base}/data/kbo_crawler_data/index.json`, null),
         fetchSafeJson(`${base}/data/teamChants.json`, []),
         fetchSafeJson(`${base}/data/kboPlayers.json`, []),
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
+        fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
       ]);
 
       console.log('로드된 데이터:', {
         songsCount: songsData?.length,
         lineupFiles: lineupIndex?.length,
         teamChantsCount: teamChantsData?.length,
-        kboPlayersCount: kboPlayersData?.length
+        kboPlayersCount: kboPlayersData?.length,
+        teamRankCount: teamRankData?.results?.length,
       });
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
@@ -381,11 +384,16 @@ const useKboData = () => {
       setPlayerSongs(parsedSongs);
       setGameLineups(finalLineups);
       setTeamChants(parsedTeamChants);
+      const ranks = Array.isArray(teamRankData?.results)
+        ? teamRankData.results
+        : [];
+      setTeamRanks(ranks);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
         gameLineups: finalLineups.length,
-        teamChants: parsedTeamChants.length
+        teamChants: parsedTeamChants.length,
+        teamRanks: ranks.length,
       });
 
     } catch (err) {
@@ -409,6 +417,7 @@ const useKboData = () => {
     loading,
     error,
     fetchJsonData,
+    teamRanks,
   };
 };
 


### PR DESCRIPTION
## Summary
- fetch team ranks in `useKboData`
- create `RankingTab` for league standings
- add schedule modal accessible from calendar dropdown
- show team ranks next to team names in lineup view
- update navigation to display ranking tab instead of schedule

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686760c381c483318e508fb9ef2151dc