### PR TITLE
Add favorite team modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,11 @@ path – additional songs can be added as separate records in
 
 Use the "오늘의 라인업 공유하기" button in the lineup tab to share or copy the current team's lineup.
 
+## Favorite team selection
+
+On first visit the site asks you to choose your favorite team. The choice is saved
+in `localStorage` under `favoriteTeam` so it persists across sessions. If you want
+to pick again, clear your browser storage or remove that key.
+
 © 2025 Jikgwangaza. All rights reserved.
 Created and maintained by Sumin Lee.

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import TeamDropdown from './components/TeamDropdown';
 import useKboData from './hooks/useKboData';
 import Footer from './components/Footer';
 import AddToHomePopup from './components/AddToHomePopup';
+import TeamSelectModal from './components/TeamSelectModal';
 
 // simple helper to avoid logs in production
 const debugLog = (...args) => {
@@ -71,7 +72,11 @@ const JikgwanGaja = () => {
     return `${yyyy}-${mm}-${dd}`;
   });
 
-  const [selectedTeam, setSelectedTeam] = useState('KIA');
+  const [selectedTeam, setSelectedTeam] = useState(() => {
+    const stored = localStorage.getItem('favoriteTeam');
+    return stored && stored !== 'none' ? stored : 'KIA';
+  });
+  const [showTeamModal, setShowTeamModal] = useState(() => !localStorage.getItem('favoriteTeam'));
   const [selectedGameCode, setSelectedGameCode] = useState(null);
   const [playSource, setPlaySource] = useState('lineup');
   const [currentLineupIndex, setCurrentLineupIndex] = useState(0);
@@ -686,6 +691,18 @@ const getSortedChants = () => {
     }
   };
 
+  const handleInitialTeam = (team) => {
+    try {
+      localStorage.setItem('favoriteTeam', team);
+    } catch {
+      // ignore write errors
+    }
+    if (team !== 'none') {
+      setSelectedTeam(team);
+    }
+    setShowTeamModal(false);
+  };
+
 
 
   
@@ -755,7 +772,17 @@ const getSortedChants = () => {
             gameDates={gameDatesForTeam}
             onOpenSchedule={() => setShowScheduleModal(true)}
           />
-          <TeamDropdown value={selectedTeam} onChange={setSelectedTeam} />
+          <TeamDropdown
+            value={selectedTeam}
+            onChange={(team) => {
+              setSelectedTeam(team);
+              try {
+                localStorage.setItem('favoriteTeam', team);
+              } catch {
+                // ignore write errors
+              }
+            }}
+          />
         </div>
      </div>
 
@@ -915,6 +942,7 @@ const getSortedChants = () => {
       </div>
       <Footer />
       <AddToHomePopup />
+      {showTeamModal && <TeamSelectModal onSelect={handleInitialTeam} />}
       {showScheduleModal && (
         <div className="fixed inset-0 z-50 flex flex-col bg-black/50 backdrop-blur-sm">
           <div className="bg-white dark:bg-gray-800 m-4 p-4 rounded-xl flex-1 overflow-y-auto">

--- a/src/components/TeamSelectModal.jsx
+++ b/src/components/TeamSelectModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { getTeamInfo } from '../utils/team';
+
+const teams = ['KIA', '두산', 'LG', '삼성', '롯데', 'SSG', '키움', '한화', 'NC', 'KT'];
+
+const TeamSelectModal = ({ onSelect }) => {
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl m-4 p-4 w-full max-w-md">
+        <h2 className="text-lg font-bold text-center mb-4">응원팀을 선택하세요</h2>
+        <div className="grid grid-cols-5 gap-4 mb-4">
+          {teams.map((team) => (
+            <button
+              key={team}
+              onClick={() => onSelect(team)}
+              className="flex flex-col items-center hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg p-2"
+            >
+              {getTeamInfo(team).logo && (
+                <img
+                  src={getTeamInfo(team).logo}
+                  alt={team}
+                  className="w-10 h-10 object-contain"
+                />
+              )}
+              <span className="text-xs mt-1 whitespace-nowrap">
+                {getTeamInfo(team).text || team}
+              </span>
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => onSelect('none')}
+          className="w-full bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg py-2 text-sm"
+        >
+          아직 응원팀이 없어요
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TeamSelectModal;


### PR DESCRIPTION
## Summary
- allow selecting a favorite team on first visit
- save team choice in localStorage
- add TeamSelectModal component with all team logos
- store updated team when changed via dropdown
- document favourite team feature

## Testing
- `npm test --silent --runTestsByPath src/App.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686764374198833187c449daf072494e