### PR TITLE
Improve ranking tab UI

### DIFF
--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -2,27 +2,52 @@ import React from 'react';
 import { getTeamInfo } from '../utils/team';
 
 const RankingTab = ({ teamRanks }) => {
-  const sorted = (teamRanks || []).slice().sort((a, b) => parseInt(a.rank) - parseInt(b.rank));
+  const sorted = (teamRanks || [])
+    .slice()
+    .sort((a, b) => parseInt(a.rank) - parseInt(b.rank));
+
   return (
-    <div className="space-y-2">
-      {sorted.map((r) => (
-        <div key={r.team} className="flex items-center justify-between bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
-          <div className="flex items-center gap-2">
-            <span className="w-5 text-sm font-bold">{r.rank}</span>
-            {getTeamInfo(r.team).logo && (
-              <img src={getTeamInfo(r.team).logo} alt={r.team} className="w-5 h-5 object-contain" />
-            )}
-            <span className="font-medium">{r.team}</span>
-          </div>
-          <div className="text-sm text-right text-gray-600 dark:text-gray-300">
-            <span>{r.wins}-{r.draws}-{r.losses}</span>
-            <span className="ml-2">{r.win_rate}</span>
-            {r.gb !== undefined && r.gb !== null && (
-              <span className="ml-2 text-xs text-gray-500">GB {r.gb}</span>
-            )}
-          </div>
-        </div>
-      ))}
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left">
+        <thead className="bg-gray-50 dark:bg-gray-700">
+          <tr>
+            <th className="px-2 py-1 font-semibold">#</th>
+            <th className="px-2 py-1 font-semibold">팀</th>
+            <th className="px-2 py-1 font-semibold text-right">승-무-패</th>
+            <th className="px-2 py-1 font-semibold text-right">승률</th>
+            <th className="px-2 py-1 font-semibold text-right">GB</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => (
+            <tr
+              key={r.team}
+              className="border-b last:border-b-0 border-gray-200 dark:border-gray-700"
+            >
+              <td className="px-2 py-1">{r.rank}</td>
+              <td className="px-2 py-1">
+                <div className="flex items-center gap-2">
+                  {getTeamInfo(r.team).logo && (
+                    <img
+                      src={getTeamInfo(r.team).logo}
+                      alt={r.team}
+                      className="w-5 h-5 object-contain"
+                    />
+                  )}
+                  <span className="font-medium">{r.team}</span>
+                </div>
+              </td>
+              <td className="px-2 py-1 text-right">
+                {r.wins}-{r.draws}-{r.losses}
+              </td>
+              <td className="px-2 py-1 text-right">{r.win_rate}</td>
+              <td className="px-2 py-1 text-right">
+                {r.gb !== undefined && r.gb !== null ? r.gb : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- render standings in a real table for clarity

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686765a1ebb48331aa7d7e9b89d108ef