### PR TITLE
Add ranking table

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -847,6 +847,20 @@ const getSortedChants = () => {
           <Search className="w-6 h-6" />
           <span className="text-xs">탐색</span>
         </button>
+        <button
+          onClick={() => {
+            setActiveTab('ranking');
+            setShowPlayer(false);
+          }}
+          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
+            activeTab === 'ranking' && !showPlayer
+              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
+              : 'text-gray-600'
+          }`}
+        >
+          <Trophy className="w-6 h-6" />
+          <span className="text-xs">순위</span>
+        </button>
       </div>
 
      {/* 메인 콘텐츠 */}
@@ -943,9 +957,10 @@ const getSortedChants = () => {
                 handleShare={handleShare}
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}
-                setCurrentPlayerName={setCurrentPlayerName}
-              />
+              setCurrentPlayerName={setCurrentPlayerName}
+            />
             )}
+            {activeTab === 'ranking' && <RankingTab teamRanks={teamRanks} />}
           </>
         )}
       </div>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { getTeamInfo } from '../utils/team';
+
+const RankingTab = ({ teamRanks }) => {
+  if (!Array.isArray(teamRanks) || teamRanks.length === 0) {
+    return (
+      <p className="text-center text-gray-500">순위 데이터를 불러올 수 없습니다.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-200">
+            <th className="p-2 text-center">순위</th>
+            <th className="p-2 text-left">팀</th>
+            <th className="p-2 text-center">승</th>
+            <th className="p-2 text-center">무</th>
+            <th className="p-2 text-center">패</th>
+            <th className="p-2 text-center">승률</th>
+            <th className="p-2 text-center">게임차</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+          {teamRanks.map((t) => (
+            <tr key={t.team} className="bg-white dark:bg-gray-800">
+              <td className="p-2 text-center font-medium">{t.rank}</td>
+              <td className="p-2">
+                <div className="flex items-center gap-2">
+                  {getTeamInfo(t.team).logo && (
+                    <img
+                      src={getTeamInfo(t.team).logo}
+                      alt={t.team}
+                      className="w-5 h-5 object-contain"
+                    />
+                  )}
+                  <span>{t.team}</span>
+                </div>
+              </td>
+              <td className="p-2 text-center">{t.wins}</td>
+              <td className="p-2 text-center">{t.draws}</td>
+              <td className="p-2 text-center">{t.losses}</td>
+              <td className="p-2 text-center">{t.win_rate}</td>
+              <td className="p-2 text-center">{t.gb}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RankingTab;


### PR DESCRIPTION
## Summary
- create RankingTab component for displaying standings
- show ranking tab in navigation and main content

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676bf8518483318ca2c443cfad65b9