### PR TITLE
Ensure team ranks file is overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Run it manually:
 python public/kbo_team_rank_crawler.py --output public/data/teamRank.json
 ```
 
+This output file is overwritten each run so historical rankings are **not**
+accumulated. Use version control if you wish to keep old snapshots.
+
 The crawler also runs automatically each day via GitHub Actions.
 
 ## Crawling player info

--- a/public/kbo_team_rank_crawler.py
+++ b/public/kbo_team_rank_crawler.py
@@ -112,11 +112,15 @@ def fetch_team_ranks(
 
 
 def save_ranks(ranks: list, path: str = "public/data/teamRank.json") -> None:
+    """Write ranking data to ``path``, overwriting any existing file."""
+
     os.makedirs(os.path.dirname(path), exist_ok=True)
     data = {
         "crawl_time": datetime.now().isoformat(),
         "results": ranks,
     }
+
+    # ``w`` mode ensures the file is replaced each run rather than appended to
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
## Summary
- clarify that the team ranks crawler overwrites the output file
- note this behaviour in README

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676f0932748331aad2a67e0f4478ae