### PR TITLE
Display ranking update time

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -199,6 +199,7 @@ const JikgwanGaja = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -917,6 +918,9 @@ const getSortedChants = () => {
                 setSelectedDate={setSelectedDate}
                 setActiveTab={setActiveTab}
               />
+            )}
+            {activeTab === 'ranking' && (
+              <RankingTab teamRanks={teamRanks} updatedAt={teamRankTime} />
             )}
             {activeTab === 'explore' && (
               <ExploreTab

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { getTeamInfo } from '../utils/team';
+
+const RankingTab = ({ teamRanks, updatedAt }) => {
+  const sorted = (teamRanks || []).slice().sort((a, b) => parseInt(a.rank) - parseInt(b.rank));
+
+  const formatUpdateTime = (iso) => {
+    if (!iso) return '';
+    const date = new Date(iso);
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mi = String(date.getMinutes()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
+  };
+
+  return (
+    <div className="space-y-2">
+      {updatedAt && (
+        <div className="text-sm text-gray-500 text-right">
+          업데이트: {formatUpdateTime(updatedAt)} 기준
+        </div>
+      )}
+      {sorted.map((r) => (
+        <div key={r.team} className="flex items-center justify-between bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <div className="flex items-center gap-2">
+            <span className="w-5 text-sm font-bold">{r.rank}</span>
+            {getTeamInfo(r.team).logo && (
+              <img src={getTeamInfo(r.team).logo} alt={r.team} className="w-5 h-5 object-contain" />
+            )}
+            <span className="font-medium">{r.team}</span>
+          </div>
+          <div className="text-sm text-right text-gray-600 dark:text-gray-300">
+            <span>{r.wins}-{r.draws}-{r.losses}</span>
+            <span className="ml-2">{r.win_rate}</span>
+            {r.gb !== undefined && r.gb !== null && (
+              <span className="ml-2 text-xs text-gray-500">GB {r.gb}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RankingTab;

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -98,6 +98,7 @@ const useKboData = () => {
   const [kboPlayers, setKboPlayers] = useState([]);
   const [rawSongs, setRawSongs] = useState([]);
   const [teamRanks, setTeamRanks] = useState([]);
+  const [teamRankTime, setTeamRankTime] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -124,7 +125,7 @@ const useKboData = () => {
         fetchSafeJson(`${base}/data/teamChants.json`, []),
         fetchSafeJson(`${base}/data/kboPlayers.json`, []),
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
-        fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
+        fetchSafeJson(`${base}/data/teamRank.json`, { results: [], crawl_time: null }),
       ]);
 
       console.log('로드된 데이터:', {
@@ -388,6 +389,7 @@ const useKboData = () => {
         ? teamRankData.results
         : [];
       setTeamRanks(ranks);
+      setTeamRankTime(teamRankData?.crawl_time || null);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
@@ -418,6 +420,7 @@ const useKboData = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   };
 };
 


### PR DESCRIPTION
## Summary
- handle team ranking crawl time in data hook
- show crawl timestamp in RankingTab
- pass ranking time to RankingTab

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676ed4713083319adcce2739c60a55