### PR TITLE
Restore ranking tab and reorder nav

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -115,7 +115,7 @@ const JikgwanGaja = () => {
       const tab = window.location.hash.replace('#', '');
       if (
         tab &&
-        ['lineup', 'teamChants', 'schedule', 'explore', 'ranking'].includes(tab)
+        ['lineup', 'teamChants', 'explore', 'ranking', 'schedule'].includes(tab)
       ) {
         setActiveTab(tab);
         setShowPlayer(false);
@@ -821,20 +821,6 @@ const getSortedChants = () => {
         </button>
         <button
           onClick={() => {
-            setActiveTab('schedule');
-            setShowPlayer(false);
-          }}
-          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
-            activeTab === 'schedule' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
-          }`}
-        >
-          <Calendar className="w-6 h-6" />
-          <span className="text-xs">일정</span>
-        </button>
-        <button
-          onClick={() => {
             setActiveTab('explore');
             setShowPlayer(false);
           }}
@@ -846,6 +832,34 @@ const getSortedChants = () => {
         >
           <Search className="w-6 h-6" />
           <span className="text-xs">탐색</span>
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab('ranking');
+            setShowPlayer(false);
+          }}
+          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
+            activeTab === 'ranking' && !showPlayer
+              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
+              : 'text-gray-600'
+          }`}
+        >
+          <Trophy className="w-6 h-6" />
+          <span className="text-xs">순위</span>
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab('schedule');
+            setShowPlayer(false);
+          }}
+          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
+            activeTab === 'schedule' && !showPlayer
+              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
+              : 'text-gray-600'
+          }`}
+        >
+          <Calendar className="w-6 h-6" />
+          <span className="text-xs">일정</span>
         </button>
       </div>
 
@@ -909,15 +923,6 @@ const getSortedChants = () => {
                 loading={loading}
               />
             )}
-            {activeTab === 'schedule' && (
-              <ScheduleTab
-                selectedTeam={selectedTeam}
-                gameLineups={gameLineups}
-                formatDateKorean={formatDateKorean}
-                setSelectedDate={setSelectedDate}
-                setActiveTab={setActiveTab}
-              />
-            )}
             {activeTab === 'explore' && (
               <ExploreTab
                 searchQuery={searchQuery}
@@ -944,6 +949,16 @@ const getSortedChants = () => {
                 setSearchQuery={setSearchQuery}
                 isComposing={isComposing}
                 setCurrentPlayerName={setCurrentPlayerName}
+              />
+            )}
+            {activeTab === 'ranking' && <RankingTab teamRanks={teamRanks} />}
+            {activeTab === 'schedule' && (
+              <ScheduleTab
+                selectedTeam={selectedTeam}
+                gameLineups={gameLineups}
+                formatDateKorean={formatDateKorean}
+                setSelectedDate={setSelectedDate}
+                setActiveTab={setActiveTab}
               />
             )}
           </>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { getTeamInfo } from '../utils/team';
+
+const RankingTab = ({ teamRanks }) => {
+  const sorted = (teamRanks || []).slice().sort((a, b) => parseInt(a.rank) - parseInt(b.rank));
+  return (
+    <div className="space-y-2">
+      {sorted.map((r) => (
+        <div
+          key={r.team}
+          className="flex items-center justify-between bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3"
+        >
+          <div className="flex items-center gap-2">
+            <span className="w-5 text-sm font-bold">{r.rank}</span>
+            {getTeamInfo(r.team).logo && (
+              <img src={getTeamInfo(r.team).logo} alt={r.team} className="w-5 h-5 object-contain" />
+            )}
+            <span className="font-medium">{r.team}</span>
+          </div>
+          <div className="text-sm text-right text-gray-600 dark:text-gray-300">
+            <span>{r.wins}-{r.draws}-{r.losses}</span>
+            <span className="ml-2">{r.win_rate}</span>
+            {r.gb !== undefined && r.gb !== null && (
+              <span className="ml-2 text-xs text-gray-500">GB {r.gb}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RankingTab;


### PR DESCRIPTION
## Summary
- restore `RankingTab` component
- update allowed tab list
- reorder tab navigation and include ranking
- render ranking tab before schedule tab

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676e8fea608331849c5742300c4d61