### PR TITLE
Display starting pitcher in lineup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -336,9 +336,6 @@ const JikgwanGaja = () => {
           return null;
         }
   
-        // 만약 lineupPlayer에 선발투수 정보가 있을 때 null 체크
-        const pitcherName = lineupPlayer.starting_pitcher?.name || "-";
-  
         // Only the first matching song is used for lineup display.
         const song = playerSongs.find(song =>
           song && song.playerName === lineupPlayer.playerName && song.team === selectedTeam

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -145,6 +145,14 @@ const LineupTab = ({
             </div>
           </div>
 
+          {currentGame.startingPitcher && (
+            <div className="mb-4 text-sm font-medium text-gray-700 dark:text-gray-300">
+              오늘 선발투수: {currentGame.startingPitcher.playerName}
+              {currentGame.startingPitcher.throwingHand &&
+                ` (${currentGame.startingPitcher.throwingHand})`}
+            </div>
+          )}
+
           {currentGame.canceled ? (
             <div className="text-center py-8 text-gray-500">
               <AlertCircle className="w-12 h-12 mx-auto mb-4 opacity-50" />

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -286,19 +286,33 @@ const useKboData = () => {
               return [];
             }
 
-            const buildLineup = (lineupObj, teamName) => {
-              if (!Array.isArray(lineupObj?.starting_batters)) {
-                console.warn('타자 라인업 없음:', teamName, file);
-                return [];
+            const buildLineupData = (lineupObj, teamName) => {
+              if (!lineupObj) return { pitcher: null, batters: [] };
+
+              let pitcher = null;
+              if (lineupObj.starting_pitcher) {
+                const sp = lineupObj.starting_pitcher;
+                pitcher = {
+                  playerName: sp.name,
+                  throwingHand: sp.throwing_hand,
+                  position: normalizePosition(sp.position || '투수'),
+                };
               }
 
-              return lineupObj.starting_batters
-                .map((batter) => ({
-                  order: batter.batting_order,
-                  playerName: batter.name,
-                  position: normalizePosition(batter.position),
-                }))
-                .sort((a, b) => a.order - b.order);
+              let batters = [];
+              if (Array.isArray(lineupObj.starting_batters)) {
+                batters = lineupObj.starting_batters
+                  .map((batter) => ({
+                    order: batter.batting_order,
+                    playerName: batter.name,
+                    position: normalizePosition(batter.position),
+                  }))
+                  .sort((a, b) => a.order - b.order);
+              } else {
+                console.warn('타자 라인업 없음:', teamName, file);
+              }
+
+              return { pitcher, batters };
             };
 
             const team1Name = normalizeTeamName(game.starting_lineups?.team_1?.team_name || '');
@@ -309,12 +323,12 @@ const useKboData = () => {
               return [];
             }
 
-            const lineup1 = isCanceled
-              ? []
-              : buildLineup(game.starting_lineups?.team_1, team1Name);
-            const lineup2 = isCanceled
-              ? []
-              : buildLineup(game.starting_lineups?.team_2, team2Name);
+            const lineupData1 = isCanceled
+              ? { pitcher: null, batters: [] }
+              : buildLineupData(game.starting_lineups?.team_1, team1Name);
+            const lineupData2 = isCanceled
+              ? { pitcher: null, batters: [] }
+              : buildLineupData(game.starting_lineups?.team_2, team2Name);
 
             return [
               {
@@ -326,7 +340,8 @@ const useKboData = () => {
                 away: awayTeam,
                 location: location,
                 gameTime: gameTime,
-                lineup: lineup1,
+                lineup: lineupData1.batters,
+                startingPitcher: lineupData1.pitcher,
                 canceled: isCanceled,
                 gameStatus: game.game_status,
               },
@@ -339,7 +354,8 @@ const useKboData = () => {
                 away: awayTeam,
                 location: location,
                 gameTime: gameTime,
-                lineup: lineup2,
+                lineup: lineupData2.batters,
+                startingPitcher: lineupData2.pitcher,
                 canceled: isCanceled,
                 gameStatus: game.game_status,
               },
@@ -364,6 +380,18 @@ const useKboData = () => {
           date: normalizeDate(game.date),
         }));
       }
+
+      finalLineups = finalLineups.map(game => {
+        let { lineup, startingPitcher } = game;
+        if (!startingPitcher && Array.isArray(lineup) && lineup.length === 10) {
+          const possiblePitcher = lineup[lineup.length - 1];
+          if (possiblePitcher.position === '투수') {
+            startingPitcher = { playerName: possiblePitcher.playerName };
+            lineup = lineup.slice(0, 9);
+          }
+        }
+        return { ...game, lineup, startingPitcher };
+      });
 
       // 팀 응원가 데이터 처리
       const parsedTeamChants = Array.isArray(teamChantsData)


### PR DESCRIPTION
## Summary
- parse `starting_pitcher` from crawler data in `useKboData`
- carry starting pitcher through lineup objects
- show today's starting pitcher on `LineupTab`
- remove unused pitcher check in `App`

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676f61dbb08331b56f1a3f4dde78d6