### PR TITLE
Reorder tab navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -115,7 +115,7 @@ const JikgwanGaja = () => {
       const tab = window.location.hash.replace('#', '');
       if (
         tab &&
-        ['lineup', 'teamChants', 'schedule', 'explore', 'ranking'].includes(tab)
+        ['lineup', 'teamChants', 'explore', 'ranking', 'schedule'].includes(tab)
       ) {
         setActiveTab(tab);
         setShowPlayer(false);
@@ -821,20 +821,6 @@ const getSortedChants = () => {
         </button>
         <button
           onClick={() => {
-            setActiveTab('schedule');
-            setShowPlayer(false);
-          }}
-          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
-            activeTab === 'schedule' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
-          }`}
-        >
-          <Calendar className="w-6 h-6" />
-          <span className="text-xs">일정</span>
-        </button>
-        <button
-          onClick={() => {
             setActiveTab('explore');
             setShowPlayer(false);
           }}
@@ -860,6 +846,20 @@ const getSortedChants = () => {
         >
           <Trophy className="w-6 h-6" />
           <span className="text-xs">순위</span>
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab('schedule');
+            setShowPlayer(false);
+          }}
+          className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
+            activeTab === 'schedule' && !showPlayer
+              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
+              : 'text-gray-600'
+          }`}
+        >
+          <Calendar className="w-6 h-6" />
+          <span className="text-xs">일정</span>
         </button>
       </div>
 
@@ -923,15 +923,6 @@ const getSortedChants = () => {
                 loading={loading}
               />
             )}
-            {activeTab === 'schedule' && (
-              <ScheduleTab
-                selectedTeam={selectedTeam}
-                gameLineups={gameLineups}
-                formatDateKorean={formatDateKorean}
-                setSelectedDate={setSelectedDate}
-                setActiveTab={setActiveTab}
-              />
-            )}
             {activeTab === 'explore' && (
               <ExploreTab
                 searchQuery={searchQuery}
@@ -961,6 +952,15 @@ const getSortedChants = () => {
             />
             )}
             {activeTab === 'ranking' && <RankingTab teamRanks={teamRanks} />}
+            {activeTab === 'schedule' && (
+              <ScheduleTab
+                selectedTeam={selectedTeam}
+                gameLineups={gameLineups}
+                formatDateKorean={formatDateKorean}
+                setSelectedDate={setSelectedDate}
+                setActiveTab={setActiveTab}
+              />
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- reorder tab list to lineup > team cheers > explore > ranking > schedule
- move schedule tab to the end of navigation buttons
- render content in same order

## Testing
- `CI=true npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686770f1611c83318a8b77a81e5e5292