### PR TITLE
Add last update info to ranking

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -199,6 +199,7 @@ const JikgwanGaja = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -960,7 +961,9 @@ const getSortedChants = () => {
               setCurrentPlayerName={setCurrentPlayerName}
             />
             )}
-            {activeTab === 'ranking' && <RankingTab teamRanks={teamRanks} />}
+            {activeTab === 'ranking' && (
+              <RankingTab teamRanks={teamRanks} teamRankTime={teamRankTime} />
+            )}
           </>
         )}
       </div>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,7 +1,19 @@
 import React from 'react';
 import { getTeamInfo } from '../utils/team';
 
-const RankingTab = ({ teamRanks }) => {
+const formatDateTimeKorean = (iso) => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d)) return iso;
+  const y = d.getFullYear();
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${y}년 ${m}월 ${day}일 ${hh}시 ${mm}분`;
+};
+
+const RankingTab = ({ teamRanks, teamRankTime }) => {
   if (!Array.isArray(teamRanks) || teamRanks.length === 0) {
     return (
       <p className="text-center text-gray-500">순위 데이터를 불러올 수 없습니다.</p>
@@ -9,8 +21,14 @@ const RankingTab = ({ teamRanks }) => {
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full text-sm">
+    <div className="space-y-1">
+      {teamRankTime && (
+        <p className="text-right text-xs text-gray-500">
+          업데이트: {formatDateTimeKorean(teamRankTime)}
+        </p>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
         <thead>
           <tr className="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-200">
             <th className="p-2 text-center">순위</th>
@@ -47,6 +65,7 @@ const RankingTab = ({ teamRanks }) => {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 };

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -98,6 +98,7 @@ const useKboData = () => {
   const [kboPlayers, setKboPlayers] = useState([]);
   const [rawSongs, setRawSongs] = useState([]);
   const [teamRanks, setTeamRanks] = useState([]);
+  const [teamRankTime, setTeamRankTime] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -388,6 +389,7 @@ const useKboData = () => {
         ? teamRankData.results
         : [];
       setTeamRanks(ranks);
+      setTeamRankTime(teamRankData?.crawl_time || null);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
@@ -418,6 +420,7 @@ const useKboData = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   };
 };
 


### PR DESCRIPTION
## Summary
- return `crawl_time` from `teamRank.json`
- show last update time at top of ranking tab

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867710ae7208331ade254ffa02c397b