### PR TITLE
Display ranking update time

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -199,6 +199,7 @@ const JikgwanGaja = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -948,7 +949,9 @@ const getSortedChants = () => {
               setCurrentPlayerName={setCurrentPlayerName}
             />
             )}
-            {activeTab === 'ranking' && <RankingTab teamRanks={teamRanks} />}
+            {activeTab === 'ranking' && (
+              <RankingTab teamRanks={teamRanks} rankUpdatedAt={teamRankTime} />
+            )}
             {activeTab === 'schedule' && (
               <ScheduleTab
                 selectedTeam={selectedTeam}

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -1,16 +1,37 @@
 import React from 'react';
 import { getTeamInfo } from '../utils/team';
 
-const RankingTab = ({ teamRanks }) => {
+const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
   if (!Array.isArray(teamRanks) || teamRanks.length === 0) {
     return (
       <p className="text-center text-gray-500">순위 데이터를 불러올 수 없습니다.</p>
     );
   }
 
+  const formatUpdatedAt = (iso) => {
+    try {
+      const d = new Date(iso);
+      if (isNaN(d)) return '';
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      const h = String(d.getHours()).padStart(2, '0');
+      const min = String(d.getMinutes()).padStart(2, '0');
+      return `${y}년 ${m}월 ${day}일 ${h}시 ${min}분`;
+    } catch (e) {
+      return '';
+    }
+  };
+
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full text-sm">
+    <div className="space-y-2">
+      {rankUpdatedAt && (
+        <p className="text-right text-xs text-gray-500">
+          {formatUpdatedAt(rankUpdatedAt)} 기준
+        </p>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
         <thead>
           <tr className="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-200">
             <th className="p-2 text-center">순위</th>
@@ -48,6 +69,7 @@ const RankingTab = ({ teamRanks }) => {
         </tbody>
       </table>
     </div>
+  </div>
   );
 };
 

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -98,6 +98,7 @@ const useKboData = () => {
   const [kboPlayers, setKboPlayers] = useState([]);
   const [rawSongs, setRawSongs] = useState([]);
   const [teamRanks, setTeamRanks] = useState([]);
+  const [teamRankTime, setTeamRankTime] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -416,6 +417,7 @@ const useKboData = () => {
         ? teamRankData.results
         : [];
       setTeamRanks(ranks);
+      setTeamRankTime(teamRankData?.crawl_time || null);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
@@ -446,6 +448,7 @@ const useKboData = () => {
     error,
     fetchJsonData,
     teamRanks,
+    teamRankTime,
   };
 };
 


### PR DESCRIPTION
## Summary
- surface crawl time from teamRank.json via `useKboData`
- pass timestamp to `RankingTab`
- show last update time above the rankings table

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867754ec9588331ac29ca542678118c