### PR TITLE
Fix schedule crawler driver lifetime

### DIFF
--- a/public/kbo_schedule_crawler.py
+++ b/public/kbo_schedule_crawler.py
@@ -8,19 +8,21 @@ from kbo_crawler import NaverKBOAllLineupCrawler
 
 def fetch_schedule(start_date: str, end_date: str) -> list:
     """Fetch schedule data between the given dates inclusive."""
-    crawler = NaverKBOAllLineupCrawler()
     results = []
-    try:
-        start = datetime.strptime(start_date, "%Y-%m-%d")
-        end = datetime.strptime(end_date, "%Y-%m-%d")
-        current = start
-        while current <= end:
-            date_str = current.strftime("%Y-%m-%d")
+    start = datetime.strptime(start_date, "%Y-%m-%d")
+    end = datetime.strptime(end_date, "%Y-%m-%d")
+    current = start
+
+    while current <= end:
+        date_str = current.strftime("%Y-%m-%d")
+        crawler = NaverKBOAllLineupCrawler()  # Create a new driver per day
+        try:
             games = crawler.get_daily_games(date_str)
             results.extend(games)
-            current += timedelta(days=1)
-    finally:
-        crawler.close()
+        finally:
+            crawler.close()
+        current += timedelta(days=1)
+
     return results
 
 


### PR DESCRIPTION
## Summary
- ensure kbo schedule crawler creates a new Selenium driver for each day

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677732c2708331bf4988d9b349913a