### PR TITLE
Filter pitcher cheer songs

### DIFF
--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Play } from "lucide-react";
+import { getPositionKorean } from "../utils/team";
 
 const PlayerCard = ({
   player,
@@ -33,6 +34,8 @@ const PlayerCard = ({
     setShowPlayer(true);
   };
 
+  const isPitcher = getPositionKorean(player.position) === '투수';
+
   return (
     <div
       onClick={openPlayer}
@@ -55,16 +58,18 @@ const PlayerCard = ({
           </div>
         </div>
         <div className="flex flex-col items-center gap-2">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              openPlayer();
-            }}
-            className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
-            aria-label={`${player.playerName} 응원가 재생`}
-          >
-            <Play className="w-4 h-4" />
-          </button>
+          {!isPitcher && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                openPlayer();
+              }}
+              className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
+              aria-label={`${player.playerName} 응원가 재생`}
+            >
+              <Play className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -14,6 +14,8 @@ const PlayerSongsCard = ({
   if (!chants || chants.length === 0) return null;
   const first = chants[0];
 
+  const isPitcher = getPositionKorean(first.position) === '투수';
+
   const openPlayer = () => {
     const idx = playerSongs.findIndex(
       (c) => c.playerName === first.playerName && c.team === first.team
@@ -75,16 +77,22 @@ const PlayerSongsCard = ({
           </button>
         </div>
       </div>
-      <button
-        className="w-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-2 px-3 rounded-xl flex items-center justify-center gap-2 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-        onClick={(e) => {
-          e.stopPropagation();
-          openPlayer();
-        }}
-      >
-        <Play className="w-4 h-4 text-blue-600" />
-        <span className="font-medium text-gray-900 dark:text-gray-100">응원가 재생</span>
-      </button>
+      {isPitcher ? (
+        <div className="w-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-2 px-3 rounded-xl text-center text-sm text-gray-500">
+          투수는 개인 응원가가 없습니다
+        </div>
+      ) : (
+        <button
+          className="w-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-2 px-3 rounded-xl flex items-center justify-center gap-2 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            openPlayer();
+          }}
+        >
+          <Play className="w-4 h-4 text-blue-600" />
+          <span className="font-medium text-gray-900 dark:text-gray-100">응원가 재생</span>
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -57,6 +57,7 @@ const PlayerTab = ({
     return getTeamInfo(baseTeam).text;
   };
   const getDisplayPosition = () => currentChant.position;
+  const isPitcher = getPositionKorean(getDisplayPosition()) === '투수';
   const opts = {
     width: '100%',
     height: '100%',
@@ -164,7 +165,7 @@ const PlayerTab = ({
           )}
         </div>
       </div>
-      {songsForPlayer.length > 1 && (
+      {!isPitcher && songsForPlayer.length > 1 && (
         <div className="flex items-center gap-2 overflow-x-auto pb-1">
           {songsForPlayer.map((song, idx) => (
             <button
@@ -212,16 +213,17 @@ const PlayerTab = ({
         </button>
       </div>
       {/* YouTube 플레이어 */}
-      <div className="w-full rounded-xl overflow-hidden aspect-video">
-        {currentChant.youtubeId && currentChant.youtubeId !== 'example' ? (
-          <YouTube
-            className="w-full h-full"
-            key={`player-${currentChant.youtubeId}`}
-            videoId={currentChant.youtubeId}
-            opts={opts}
-            onReady={(event) => {
-              playerRef.current = event.target;
-            }}
+      {!isPitcher && (
+        <div className="w-full rounded-xl overflow-hidden aspect-video">
+          {currentChant.youtubeId && currentChant.youtubeId !== 'example' ? (
+            <YouTube
+              className="w-full h-full"
+              key={`player-${currentChant.youtubeId}`}
+              videoId={currentChant.youtubeId}
+              opts={opts}
+              onReady={(event) => {
+                playerRef.current = event.target;
+              }}
           />
         ) : (
           <div className="flex items-center justify-center h-full text-center text-white bg-gray-900">
@@ -235,12 +237,20 @@ const PlayerTab = ({
             </div>
           </div>
         )}
-      </div>
-      <LyricsSection
-        chant={currentChant}
-        hasVideo={!!currentChant.youtubeId && currentChant.youtubeId !== 'example'}
-        defaultExpanded
-      />
+        </div>
+      )}
+      {isPitcher && (
+        <div className="p-4 text-center text-sm text-gray-500">
+          투수는 개인 응원가가 제공되지 않습니다
+        </div>
+      )}
+      {!isPitcher && (
+        <LyricsSection
+          chant={currentChant}
+          hasVideo={!!currentChant.youtubeId && currentChant.youtubeId !== 'example'}
+          defaultExpanded
+        />
+      )}
       {/* 액션 버튼 (공유/정보 요청/플레이리스트) 제거 */}
     </div>
   );

--- a/src/components/StartingPitcherCard.jsx
+++ b/src/components/StartingPitcherCard.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Play } from 'lucide-react';
 
 const StartingPitcherCard = ({
   pitcher,
@@ -39,16 +38,6 @@ const StartingPitcherCard = ({
             </p>
           )}
         </div>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            openPlayer();
-          }}
-          className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
-          aria-label={`${pitcher.playerName} 응원가 재생`}
-        >
-          <Play className="w-4 h-4" />
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- hide play buttons for pitchers in player cards
- show info only for starting pitcher card
- skip song playback for pitchers
- note pitcher songs unavailable in explore

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867791820008331945b3d4a038674e0