### PR TITLE
Move starting pitcher card below lineup

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -146,18 +146,6 @@ const LineupTab = ({
             </div>
           </div>
 
-          {currentGame.startingPitcher && (
-            <StartingPitcherCard
-              pitcher={currentGame.startingPitcher}
-              playerSongs={playerSongs}
-              selectedTeam={selectedTeam}
-              setCurrentPlayer={setCurrentPlayer}
-              setPlaySource={setPlaySource}
-              setShowPlayer={setShowPlayer}
-              setCurrentPlayerName={setCurrentPlayerName}
-            />
-          )}
-
           {currentGame.canceled ? (
             <div className="text-center py-8 text-gray-500">
               <AlertCircle className="w-12 h-12 mx-auto mb-4 opacity-50" />
@@ -220,6 +208,18 @@ const LineupTab = ({
                 최근 라인업 보러가기
               </button>
             </div>
+          )}
+
+          {currentGame.startingPitcher && (
+            <StartingPitcherCard
+              pitcher={currentGame.startingPitcher}
+              playerSongs={playerSongs}
+              selectedTeam={selectedTeam}
+              setCurrentPlayer={setCurrentPlayer}
+              setPlaySource={setPlaySource}
+              setShowPlayer={setShowPlayer}
+              setCurrentPlayerName={setCurrentPlayerName}
+            />
           )}
         </>
       ) : (


### PR DESCRIPTION
## Summary
- reorder starting pitcher card placement in `LineupTab` so it renders after the lineup cards

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677c68499c8331b4766b058d2404b1