### PR TITLE
Update pitcher layout

### DIFF
--- a/src/components/StartingPitcherCard.jsx
+++ b/src/components/StartingPitcherCard.jsx
@@ -25,10 +25,10 @@ const StartingPitcherCard = ({
   return (
     <div
       onClick={openPlayer}
-      className="p-4 rounded-xl border-2 transition-all cursor-pointer border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900 hover:border-blue-300 dark:hover:border-blue-600 mb-4"
+      className="p-4 rounded-xl border-2 transition-all cursor-pointer border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900 hover:border-blue-300 dark:hover:border-blue-600 mb-4 max-w-xs"
     >
       <div className="flex items-center justify-between">
-        <div>
+        <div className="flex items-center gap-2">
           <h3 className="font-bold text-lg text-gray-900 dark:text-gray-100">
             {pitcher.playerName}
           </h3>


### PR DESCRIPTION
## Summary
- show starting pitcher's throwing hand inline
- limit pitcher card width so it's smaller than others

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677da4bea88331ae9ef684cd610742