### PR TITLE
Improve rank visibility in lineup tab

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -100,9 +100,9 @@ const LineupTab = ({
                   )}
                   <span className="font-semibold">{currentGame.away}</span>
                   {getRank(currentGame.away) && (
-                    <span className="text-xs text-gray-500 ml-1">(
+                    <span className="text-xs text-gray-700 dark:text-gray-300 ml-1">
                       {getRank(currentGame.away)}
-                    )</span>
+                    </span>
                   )}
                   <span className="text-xs text-gray-500">(원정)</span>
                   <span className="mx-1 text-gray-500">vs</span>
@@ -115,9 +115,9 @@ const LineupTab = ({
                   )}
                   <span className="font-semibold">{currentGame.home}</span>
                   {getRank(currentGame.home) && (
-                    <span className="text-xs text-gray-500 ml-1">(
+                    <span className="text-xs text-gray-700 dark:text-gray-300 ml-1">
                       {getRank(currentGame.home)}
-                    )</span>
+                    </span>
                   )}
                   <span className="text-xs text-gray-500">(홈)</span>
                 </div>


### PR DESCRIPTION
## Summary
- show team ranks in lineup without parentheses
- use darker color for rank display

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677efc684083319e4db5abf8ba3841