### PR TITLE
Fix recent lineup navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -208,7 +208,8 @@ const JikgwanGaja = () => {
         gameLineups
           .filter((game) => {
             const parts = game.id.split('_');
-            return parts.length >= 3 && parts[2] === selectedTeam;
+            const team = parts[parts.length - 1];
+            return parts.length >= 2 && team === selectedTeam;
           })
           .map((game) => game.id.split('_')[0])
       ),
@@ -397,10 +398,10 @@ const JikgwanGaja = () => {
         if (!game || !game.id) return false;
 
         const parts = game.id.split('_');
-        if (parts.length < 3) return false;
+        if (parts.length < 2) return false;
 
         const gameDateStr = parts[0];
-        const gameTeam = parts[2];
+        const gameTeam = parts[parts.length - 1];
         const gameDateISO = normalizeDate(gameDateStr);
 
         const isValidGame =
@@ -463,9 +464,9 @@ const JikgwanGaja = () => {
       .filter((game) => {
         if (!game || !game.id) return false;
         const parts = game.id.split('_');
-        if (parts.length < 3) return false;
+        if (parts.length < 2) return false;
         const gameDateStr = parts[0];
-        const team = parts[2];
+        const team = parts[parts.length - 1];
         const gameDateISO = normalizeDate(gameDateStr);
         return gameDateISO === selectedDateISO && team === selectedTeam;
       })

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -215,7 +215,8 @@ const LineupTab = ({
                     const recentGame = gameLineups
                       .filter((game) => {
                         const idParts = game.id.split('_');
-                        return idParts.length >= 3 && idParts[2] === selectedTeam;
+                        const team = idParts[idParts.length - 1];
+                        return idParts.length >= 2 && team === selectedTeam;
                       })
                       .sort((a, b) => {
                         const dateA = a.id.split('_')[0];
@@ -283,7 +284,8 @@ const LineupTab = ({
               const recentGame = gameLineups
                 .filter((game) => {
                   const idParts = game.id.split('_');
-                  return idParts.length >= 3 && idParts[2] === selectedTeam;
+                  const team = idParts[idParts.length - 1];
+                  return idParts.length >= 2 && team === selectedTeam;
                 })
                 .sort((a, b) => {
                   const dateA = a.id.split('_')[0];


### PR DESCRIPTION
## Summary
- adjust id parsing logic for game lineups
- fix "최근 라인업 보러가기" filter so it works with new id format

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686782957a7c83319d23bbbbb493bda2