### PR TITLE
Improve ranking table alignment

### DIFF
--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -30,25 +30,25 @@ const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
           {formatUpdatedAt(rankUpdatedAt)} 기준
         </p>
       )}
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
+      <div className="flex justify-center">
+        <table className="w-full sm:min-w-[480px] text-sm">
         <thead>
           <tr className="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-200">
-            <th className="p-2 text-center">순위</th>
-            <th className="p-2 text-left">팀</th>
-            <th className="p-2 text-center">승</th>
-            <th className="p-2 text-center">무</th>
-            <th className="p-2 text-center">패</th>
-            <th className="p-2 text-center">승률</th>
-            <th className="p-2 text-center">게임차</th>
+            <th className="p-2 text-center whitespace-nowrap">순위</th>
+            <th className="p-2 text-center whitespace-nowrap">팀</th>
+            <th className="p-2 text-center whitespace-nowrap">승</th>
+            <th className="p-2 text-center whitespace-nowrap">무</th>
+            <th className="p-2 text-center whitespace-nowrap">패</th>
+            <th className="p-2 text-center whitespace-nowrap">승률</th>
+            <th className="p-2 text-center whitespace-nowrap">게임차</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {teamRanks.map((t) => (
             <tr key={t.team} className="bg-white dark:bg-gray-800">
               <td className="p-2 text-center font-medium">{t.rank}</td>
-              <td className="p-2">
-                <div className="flex items-center gap-2">
+              <td className="p-2 text-center">
+                <div className="flex items-center justify-center gap-2">
                   {getTeamInfo(t.team).logo && (
                     <img
                       src={getTeamInfo(t.team).logo}


### PR DESCRIPTION
## Summary
- center the ranking table
- keep headers on a single line without causing horizontal scroll

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867843659c08331b333812eb88b3173