### PR TITLE
Fix recent lineup button

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -213,7 +213,13 @@ const LineupTab = ({
                 <button
                   onClick={() => {
                     const recentGame = gameLineups
-                      .filter((game) => game.team === selectedTeam)
+                      .filter(
+                        (game) =>
+                          game.team === selectedTeam &&
+                          Array.isArray(game.lineup) &&
+                          game.lineup.length > 0 &&
+                          !game.canceled
+                      )
                       .sort(
                         (a, b) => new Date(b.date) - new Date(a.date)
                       )[0];
@@ -278,7 +284,13 @@ const LineupTab = ({
           <button
             onClick={() => {
               const recentGame = gameLineups
-                .filter((game) => game.team === selectedTeam)
+                .filter(
+                  (game) =>
+                    game.team === selectedTeam &&
+                    Array.isArray(game.lineup) &&
+                    game.lineup.length > 0 &&
+                    !game.canceled
+                )
                 .sort((a, b) => new Date(b.date) - new Date(a.date))[0];
 
               if (recentGame) {


### PR DESCRIPTION
## Summary
- ensure the "최근 라인업 보러가기" button only selects games with an actual lineup

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686787fee0288331a694cc78da7bc83b