### PR TITLE
Add dark mode toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,17 @@
 
       gtag('config', 'G-ZWBCTD6S6P');
     </script>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (stored === 'dark' || (!stored && prefersDark)) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,8 @@ import {
   MessageCircle,
   ThumbsUp,
   RefreshCw,
+  Moon,
+  Sun,
   AlertCircle,
   Trophy,
   Calendar
@@ -774,6 +776,16 @@ const getSortedChants = () => {
           className="p-2 rounded-full hover:bg-gray-100"
         >
           <RefreshCw className="w-4 h-4 text-gray-600" />
+        </button>
+        <button
+          onClick={() => setIsDarkMode(!isDarkMode)}
+          className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
+        >
+          {isDarkMode ? (
+            <Sun className="w-4 h-4 text-yellow-500" />
+          ) : (
+            <Moon className="w-4 h-4 text-gray-600" />
+          )}
         </button>
       </div>
        </div>


### PR DESCRIPTION
## Summary
- add theme toggle script to prevent flash
- add Moon/Sun dark mode toggle button in header

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b84cd3a08331a89242696b0ed354