### PR TITLE
Default batter-only filter in Explore tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,8 @@ const JikgwanGaja = () => {
   
   const [exploreTeamFilter, setExploreTeamFilter] = useState('전체');
   const [hasSongOnly, setHasSongOnly] = useState(false);
-  const [hasBatterOnly, setHasBatterOnly] = useState(false);
+  // 기본적으로 투수를 제외하고 타자만 표시한다
+  const [hasBatterOnly, setHasBatterOnly] = useState(true);
 
   const [currentPlayer, setCurrentPlayer] = useState(0);
   const [activeTab, setActiveTab] = useState('lineup');


### PR DESCRIPTION
## Summary
- turn on batter-only filter by default so pitchers are hidden when Explore first loads

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ff30f788833190945685ec0c8f32