### PR TITLE
Fix dark mode styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -822,8 +822,8 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'lineup' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
+              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              : 'text-gray-600 dark:text-gray-300'
           }`}
         >
           <Users className="w-6 h-6" />
@@ -836,8 +836,8 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'teamChants' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
+              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              : 'text-gray-600 dark:text-gray-300'
           }`}
         >
           <Trophy className="w-6 h-6" />
@@ -850,8 +850,8 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'explore' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
+              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              : 'text-gray-600 dark:text-gray-300'
           }`}
         >
           <Search className="w-6 h-6" />
@@ -864,8 +864,8 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'ranking' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
+              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              : 'text-gray-600 dark:text-gray-300'
           }`}
         >
           <Trophy className="w-6 h-6" />
@@ -878,8 +878,8 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'schedule' && !showPlayer
-              ? 'text-blue-600 border-b-2 border-[#005BAC] bg-white'
-              : 'text-gray-600'
+              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              : 'text-gray-600 dark:text-gray-300'
           }`}
         >
           <Calendar className="w-6 h-6" />

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -37,7 +37,7 @@ const ChantCard = ({
               <img
                 src={getTeamInfo(chant.team).logo}
                 alt={chant.team}
-                className="w-4 h-4 object-contain"
+                className="w-4 h-4 object-contain dark:invert"
               />
             )}
             <span className="font-medium px-2 py-1 rounded-full text-xs" style={{
@@ -78,13 +78,13 @@ const ChantCard = ({
         }}
         className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
       >
-        <Share2 className="w-4 h-4 text-gray-600" />
+        <Share2 className="w-4 h-4 text-gray-600 dark:text-gray-300" />
       </button>
       <button
         onClick={(e) => e.stopPropagation()}
         className="p-3 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
       >
-        <Plus className="w-4 h-4 text-gray-600" />
+        <Plus className="w-4 h-4 text-gray-600 dark:text-gray-300" />
       </button>
     </div>
   </div>

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -57,7 +57,7 @@ const ExploreTab = ({
     {/* 검색 및 필터 */}
     <div className="space-y-3">
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 w-5 h-5" />
         <input
           type="text"
           placeholder="선수명, 응원가 제목, 팀명, 포지션으로 검색"
@@ -65,17 +65,17 @@ const ExploreTab = ({
           onChange={handleChange}
           onCompositionStart={handleCompositionStart}
           onCompositionEnd={handleCompositionEnd}
-          className="w-full pl-10 pr-4 py-3 border border-gray-200 rounded-xl focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent bg-gray-50"
+          className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-[#0ea5e9] focus:border-transparent bg-gray-50 dark:bg-gray-700"
         />
       </div>
       {/* 팀 필터 */}
       <div className="space-y-2 pb-3 mb-4">
         <div className="flex items-center gap-2 flex-wrap">
-          <Filter className="w-5 h-5 text-gray-500 flex-shrink-0" />
-          <span className="text-sm text-gray-700">팀 선택</span>
+          <Filter className="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+          <span className="text-sm text-gray-700 dark:text-gray-300">팀 선택</span>
           <button
             onClick={() => setExploreTeamFilter('전체')}
-            className={`bg-white border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 ${
+            className={`bg-white dark:bg-gray-800 border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 dark:text-gray-100 ${
               exploreTeamFilter === '전체'
                 ? 'ring-2 ring-blue-500 border-transparent'
                 : 'border-gray-200'
@@ -89,7 +89,7 @@ const ExploreTab = ({
             <button
               key={team}
               onClick={() => setExploreTeamFilter(team)}
-              className={`bg-white border flex flex-col items-center p-2 rounded-lg ${
+              className={`bg-white dark:bg-gray-800 border flex flex-col items-center p-2 rounded-lg ${
                 exploreTeamFilter === team
                   ? 'ring-2 ring-blue-500 border-transparent'
                   : 'border-gray-200'
@@ -98,9 +98,9 @@ const ExploreTab = ({
               <img
                 src={getTeamInfo(team).logo}
                 alt={team}
-                className="w-8 h-8 object-contain mb-1"
+                className="w-8 h-8 object-contain mb-1 dark:invert"
               />
-              <span className="text-xs text-gray-900">{team}</span>
+              <span className="text-xs text-gray-900 dark:text-gray-100">{team}</span>
             </button>
           ))}
         </div>
@@ -110,9 +110,9 @@ const ExploreTab = ({
             type="checkbox"
             checked={hasSongOnly}
             onChange={(e) => setHasSongOnly(e.target.checked)}
-            className="w-4 h-4 text-blue-600 border-gray-300 rounded"
+            className="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"
           />
-          <label htmlFor="songOnly" className="text-sm text-gray-700 whitespace-nowrap">
+          <label htmlFor="songOnly" className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
             응원가 있는 선수만
           </label>
           <input
@@ -120,9 +120,9 @@ const ExploreTab = ({
             type="checkbox"
             checked={hasBatterOnly}
             onChange={(e) => setHasBatterOnly(e.target.checked)}
-            className="w-4 h-4 text-blue-600 border-gray-300 rounded ml-4"
+            className="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded ml-4"
           />
-          <label htmlFor="batterOnly" className="text-sm text-gray-700 whitespace-nowrap">
+          <label htmlFor="batterOnly" className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
             타자만
           </label>
         </div>
@@ -152,7 +152,7 @@ const ExploreTab = ({
             : `${exploreTeamFilter} 응원가`}
         </h2>
         <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500">{filteredChants.length}개</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">{filteredChants.length}개</span>
           <button
             onClick={() => {
               const today = new Date();
@@ -162,7 +162,7 @@ const ExploreTab = ({
               setSelectedDate(`${yyyy}-${mm}-${dd}`);
               fetchJsonData();
             }}
-            className="p-1 text-blue-600 hover:text-blue-800 transition-colors"
+            className="p-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -202,7 +202,7 @@ const ExploreTab = ({
         ));
       })()}
       {filteredChants.length === 0 && (searchQuery || exploreTeamFilter !== '전체') && !isComposing && (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Search className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>
             {searchQuery

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -95,7 +95,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.away).logo}
                       alt={currentGame.away}
-                      className="w-5 h-5 object-contain"
+                      className="w-5 h-5 object-contain dark:invert"
                     />
                   )}
                   <span className="font-semibold">{currentGame.away}</span>
@@ -110,7 +110,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.home).logo}
                       alt={currentGame.home}
-                      className="w-5 h-5 object-contain"
+                      className="w-5 h-5 object-contain dark:invert"
                     />
                   )}
                   <span className="font-semibold">{currentGame.home}</span>

--- a/src/components/LyricsSection.jsx
+++ b/src/components/LyricsSection.jsx
@@ -12,7 +12,7 @@ const LyricsSection = ({ chant, hasVideo, defaultExpanded = false }) => {
         <div>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors mb-3 font-medium"
+          className="flex items-center gap-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors mb-3 font-medium"
           >
             <Music className="w-4 h-4" />
             {isExpanded ? '가사 숨기기' : '가사 보기'}

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -42,7 +42,7 @@ const PlayerSongsCard = ({
                 <img
                   src={getTeamInfo(first.team).logo}
                   alt={first.team}
-                  className="w-4 h-4 object-contain"
+                  className="w-4 h-4 object-contain dark:invert"
                 />
               )}
               <span
@@ -73,7 +73,7 @@ const PlayerSongsCard = ({
             }}
             className="p-2 border border-gray-200 dark:border-gray-700 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 transition-all"
           >
-            <Share2 className="w-4 h-4 text-gray-600" />
+            <Share2 className="w-4 h-4 text-gray-600 dark:text-gray-300" />
           </button>
         </div>
       </div>

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -122,7 +122,7 @@ const PlayerTab = ({
                 <img
                   src={getTeamInfo(getDisplayTeam()).logo}
                   alt={getDisplayTeam()}
-                  className="w-5 h-5 object-contain"
+                  className="w-5 h-5 object-contain dark:invert"
                 />
               )}
               <span className="font-semibold" style={{ color: getTeamInfo(getDisplayTeam()).color }}>
@@ -194,7 +194,7 @@ const PlayerTab = ({
         >
           <SkipBack className="w-5 h-5" />
           {prevPlayerName && (
-            <span className="text-xs text-gray-700">{prevPlayerName}</span>
+            <span className="text-xs text-gray-700 dark:text-gray-300">{prevPlayerName}</span>
           )}
         </button>
         <button
@@ -207,7 +207,7 @@ const PlayerTab = ({
           className="flex items-center gap-1 p-2 rounded-full bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-200 transition-colors"
         >
           {nextPlayerName && (
-            <span className="text-xs text-gray-700">{nextPlayerName}</span>
+            <span className="text-xs text-gray-700 dark:text-gray-300">{nextPlayerName}</span>
           )}
           <SkipForward className="w-5 h-5" />
         </button>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -4,7 +4,7 @@ import { getTeamInfo } from '../utils/team';
 const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
   if (!Array.isArray(teamRanks) || teamRanks.length === 0) {
     return (
-      <p className="text-center text-gray-500">순위 데이터를 불러올 수 없습니다.</p>
+      <p className="text-center text-gray-500 dark:text-gray-400">순위 데이터를 불러올 수 없습니다.</p>
     );
   }
 
@@ -26,7 +26,7 @@ const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
   return (
     <div className="space-y-2">
       {rankUpdatedAt && (
-        <p className="text-right text-xs text-gray-500">
+        <p className="text-right text-xs text-gray-500 dark:text-gray-400">
           {formatUpdatedAt(rankUpdatedAt)} 기준
         </p>
       )}
@@ -53,7 +53,7 @@ const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
                     <img
                       src={getTeamInfo(t.team).logo}
                       alt={t.team}
-                      className="w-5 h-5 object-contain"
+                      className="w-5 h-5 object-contain dark:invert"
                     />
                   )}
                   <span>{t.team}</span>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -42,7 +42,7 @@ const ScheduleTab = ({
           <button
             key={opt}
             onClick={() => setLocationFilter(opt)}
-            className={`bg-white border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 ${
+            className={`bg-white dark:bg-gray-800 border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 dark:text-gray-100 ${
               locationFilter === opt
                 ? 'ring-2 ring-blue-500 border-transparent'
                 : 'border-gray-200'
@@ -83,21 +83,21 @@ const ScheduleTab = ({
                 <img
                   src={getTeamInfo(game.away).logo}
                   alt={game.away}
-                  className="w-5 h-5 object-contain"
+                  className="w-5 h-5 object-contain dark:invert"
                 />
               )}
               <span className="font-medium">{game.away}</span>
-              <span className="text-xs text-gray-500">(원정)</span>
-              <span className="mx-1 text-gray-500">vs</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">(원정)</span>
+              <span className="mx-1 text-gray-500 dark:text-gray-400">vs</span>
               {getTeamInfo(game.home).logo && (
                 <img
                   src={getTeamInfo(game.home).logo}
                   alt={game.home}
-                  className="w-5 h-5 object-contain"
+                  className="w-5 h-5 object-contain dark:invert"
                 />
               )}
               <span className="font-medium">{game.home}</span>
-              <span className="text-xs text-gray-500">(홈)</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">(홈)</span>
             </div>
             <div className="text-sm text-right text-gray-600 dark:text-gray-300">
                 <div>

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -91,11 +91,11 @@ const TeamChantsTab = ({
   return (
     <div className="space-y-6 relative">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-2xl font-bold text-gray-900">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
           {selectedTeam} 팀 응원가
         </h2>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
+          <span className="text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 px-3 py-1 rounded-full">
             {filteredChants.length}개
           </span>
           <button
@@ -107,7 +107,7 @@ const TeamChantsTab = ({
               setSelectedDate(`${yyyy}-${mm}-${dd}`);
               fetchJsonData();
             }}
-            className="p-2 text-blue-600 hover:text-blue-800 transition-colors hover:bg-blue-50 rounded-full"
+            className="p-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-full"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -115,12 +115,12 @@ const TeamChantsTab = ({
       </div>
 
       <div className="mb-4 relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 w-4 h-4" />
         {searchTerm && (
           <button
             onClick={() => setSearchTerm('')}
             aria-label="검색어 삭제"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500"
           >
             <X className="w-4 h-4" />
           </button>
@@ -131,7 +131,7 @@ const TeamChantsTab = ({
           onChange={(e) => setSearchTerm(e.target.value)}
           placeholder="응원가 제목이나 가사로 검색하세요"
           aria-label="응원가 검색"
-          className="w-full pl-9 pr-9 py-2 border border-gray-200 rounded-lg bg-gray-50 focus:ring-2 focus:ring-blue-500"
+          className="w-full pl-9 pr-9 py-2 border border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 focus:ring-2 focus:ring-blue-500"
         />
       </div>
 
@@ -143,7 +143,7 @@ const TeamChantsTab = ({
               <button
                 key={chant.id}
                 onClick={() => setActiveChantId(chant.id)}
-                className={`text-xs px-3 py-1 border rounded-lg whitespace-nowrap ${isMain ? 'text-black' : 'text-gray-900'}`}
+                className={`text-xs px-3 py-1 border rounded-lg whitespace-nowrap ${isMain ? 'text-black dark:text-white' : 'text-gray-900 dark:text-gray-100'}`}
                 style={
                   isMain
                     ? {
@@ -166,7 +166,7 @@ const TeamChantsTab = ({
       {loading ? (
         <div className="text-center py-8">
           <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-blue-500" />
-          <p className="text-gray-600">팀 응원가를 불러오는 중...</p>
+          <p className="text-gray-600 dark:text-gray-300">팀 응원가를 불러오는 중...</p>
         </div>
       ) : activeChant ? (
         <div className="space-y-4">
@@ -188,7 +188,7 @@ const TeamChantsTab = ({
               />
               {debouncedTerm && (
                 <p
-                  className="text-sm text-gray-600 mt-1"
+                  className="text-sm text-gray-600 dark:text-gray-300 mt-1"
                   dangerouslySetInnerHTML={{ __html: highlight(getSnippet(activeChant.lyrics || '', debouncedTerm), debouncedTerm) }}
                 />
               )}
@@ -204,13 +204,13 @@ const TeamChantsTab = ({
           </div>
         </div>
       ) : baseTeamChants.length === 0 ? (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Trophy className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>{selectedTeam} 팀의 응원가가 없습니다</p>
           <p className="text-sm mt-2">곧 추가될 예정입니다!</p>
         </div>
       ) : filteredChants.length === 0 ? (
-        <div className="text-center py-8 text-gray-500">
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
           <Trophy className="w-12 h-12 mx-auto mb-4 opacity-50" />
           <p>검색 결과가 없습니다</p>
         </div>
@@ -222,7 +222,7 @@ const TeamChantsTab = ({
                 <img
                   src={getTeamInfo(selectedTeam).logo}
                   alt={selectedTeam}
-                  className="w-5 h-5 object-contain"
+                  className="w-5 h-5 object-contain dark:invert"
                 />
               ) : (
                 <Trophy className="w-5 h-5" style={{ color: getTeamInfo(selectedTeam).color }} />
@@ -243,7 +243,7 @@ const TeamChantsTab = ({
                   />
                   {debouncedTerm && (
                     <p
-                      className="text-sm text-gray-600 mt-1"
+                      className="text-sm text-gray-600 dark:text-gray-300 mt-1"
                       dangerouslySetInnerHTML={{ __html: highlight(getSnippet(chant.lyrics || '', debouncedTerm), debouncedTerm) }}
                     />
                   )}

--- a/src/components/TeamSelectModal.jsx
+++ b/src/components/TeamSelectModal.jsx
@@ -19,7 +19,7 @@ const TeamSelectModal = ({ onSelect }) => {
                 <img
                   src={getTeamInfo(team).logo}
                   alt={team}
-                  className="w-10 h-10 object-contain"
+                  className="w-10 h-10 object-contain dark:invert"
                 />
               )}
               <span className="text-xs mt-1 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- tweak tab navigation styling for dark mode
- fix dark mode colors in Explore tab
- adjust Team Chants dark theme colors
- style lyrics toggle for dark theme
- improve schedule and player views for dark mode
- ensure logos are visible in dark mode

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868769f776c8331a524efa03b39d311