### PR TITLE
Fix team logos in dark mode

### DIFF
--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -37,7 +37,7 @@ const ChantCard = ({
               <img
                 src={getTeamInfo(chant.team).logo}
                 alt={chant.team}
-                className="w-4 h-4 object-contain dark:invert"
+                className="w-4 h-4 object-contain"
               />
             )}
             <span className="font-medium px-2 py-1 rounded-full text-xs" style={{

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -98,7 +98,7 @@ const ExploreTab = ({
               <img
                 src={getTeamInfo(team).logo}
                 alt={team}
-                className="w-8 h-8 object-contain mb-1 dark:invert"
+                className="w-8 h-8 object-contain mb-1"
               />
               <span className="text-xs text-gray-900 dark:text-gray-100">{team}</span>
             </button>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -95,7 +95,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.away).logo}
                       alt={currentGame.away}
-                      className="w-5 h-5 object-contain dark:invert"
+                      className="w-5 h-5 object-contain"
                     />
                   )}
                   <span className="font-semibold">{currentGame.away}</span>
@@ -110,7 +110,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.home).logo}
                       alt={currentGame.home}
-                      className="w-5 h-5 object-contain dark:invert"
+                      className="w-5 h-5 object-contain"
                     />
                   )}
                   <span className="font-semibold">{currentGame.home}</span>

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -42,7 +42,7 @@ const PlayerSongsCard = ({
                 <img
                   src={getTeamInfo(first.team).logo}
                   alt={first.team}
-                  className="w-4 h-4 object-contain dark:invert"
+                  className="w-4 h-4 object-contain"
                 />
               )}
               <span

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -122,7 +122,7 @@ const PlayerTab = ({
                 <img
                   src={getTeamInfo(getDisplayTeam()).logo}
                   alt={getDisplayTeam()}
-                  className="w-5 h-5 object-contain dark:invert"
+                  className="w-5 h-5 object-contain"
                 />
               )}
               <span className="font-semibold" style={{ color: getTeamInfo(getDisplayTeam()).color }}>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -53,7 +53,7 @@ const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
                     <img
                       src={getTeamInfo(t.team).logo}
                       alt={t.team}
-                      className="w-5 h-5 object-contain dark:invert"
+                      className="w-5 h-5 object-contain"
                     />
                   )}
                   <span>{t.team}</span>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -83,7 +83,7 @@ const ScheduleTab = ({
                 <img
                   src={getTeamInfo(game.away).logo}
                   alt={game.away}
-                  className="w-5 h-5 object-contain dark:invert"
+                  className="w-5 h-5 object-contain"
                 />
               )}
               <span className="font-medium">{game.away}</span>
@@ -93,7 +93,7 @@ const ScheduleTab = ({
                 <img
                   src={getTeamInfo(game.home).logo}
                   alt={game.home}
-                  className="w-5 h-5 object-contain dark:invert"
+                  className="w-5 h-5 object-contain"
                 />
               )}
               <span className="font-medium">{game.home}</span>

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -222,7 +222,7 @@ const TeamChantsTab = ({
                 <img
                   src={getTeamInfo(selectedTeam).logo}
                   alt={selectedTeam}
-                  className="w-5 h-5 object-contain dark:invert"
+                  className="w-5 h-5 object-contain"
                 />
               ) : (
                 <Trophy className="w-5 h-5" style={{ color: getTeamInfo(selectedTeam).color }} />

--- a/src/components/TeamSelectModal.jsx
+++ b/src/components/TeamSelectModal.jsx
@@ -19,7 +19,7 @@ const TeamSelectModal = ({ onSelect }) => {
                 <img
                   src={getTeamInfo(team).logo}
                   alt={team}
-                  className="w-10 h-10 object-contain dark:invert"
+                  className="w-10 h-10 object-contain"
                 />
               )}
               <span className="text-xs mt-1 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- show team logos with original colors in dark mode

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868920fa12c833181dece4995948316