### PR TITLE
Simplify design colors

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,7 +28,7 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  background: linear-gradient(135deg, #0ea5e9 0%, #005BAC 100%);
+  background: linear-gradient(135deg, #d1d5db 0%, #9ca3af 100%);
   color: white;
 }
 
@@ -58,7 +58,7 @@
 
 /* 헤더 스타일 */
 .App-header {
-  background: linear-gradient(135deg, #0ea5e9 0%, #005BAC 100%);
+  background: linear-gradient(135deg, #d1d5db 0%, #9ca3af 100%);
   color: white;
   padding: 16px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -102,14 +102,14 @@
 
 /* 링크 스타일 */
 .App-link {
-  color: #0ea5e9;
+  color: #4b5563;
   text-decoration: none;
   font-weight: 500;
   transition: color 0.2s ease;
 }
 
 .App-link:hover {
-  color: #005BAC;
+  color: #374151;
   text-decoration: underline;
 }
 
@@ -196,14 +196,14 @@
 
 /* 포커스 상태 개선 */
 *:focus {
-  outline: 2px solid #0ea5e9;
+  outline: 2px solid #6b7280;
   outline-offset: 2px;
 }
 
 /* 터치 기기 최적화 */
 @media (hover: none) and (pointer: coarse) {
   .App-link:hover {
-    color: #0ea5e9; /* 호버 효과 제거 */
+    color: #4b5563; /* 호버 효과 제거 */
     text-decoration: none;
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -822,7 +822,7 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'lineup' && !showPlayer
-              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              ? 'text-gray-800 dark:text-gray-200 border-b-2 border-gray-500 bg-white dark:bg-gray-900'
               : 'text-gray-600 dark:text-gray-300'
           }`}
         >
@@ -836,7 +836,7 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'teamChants' && !showPlayer
-              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              ? 'text-gray-800 dark:text-gray-200 border-b-2 border-gray-500 bg-white dark:bg-gray-900'
               : 'text-gray-600 dark:text-gray-300'
           }`}
         >
@@ -850,7 +850,7 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'explore' && !showPlayer
-              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              ? 'text-gray-800 dark:text-gray-200 border-b-2 border-gray-500 bg-white dark:bg-gray-900'
               : 'text-gray-600 dark:text-gray-300'
           }`}
         >
@@ -864,7 +864,7 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'ranking' && !showPlayer
-              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              ? 'text-gray-800 dark:text-gray-200 border-b-2 border-gray-500 bg-white dark:bg-gray-900'
               : 'text-gray-600 dark:text-gray-300'
           }`}
         >
@@ -878,7 +878,7 @@ const getSortedChants = () => {
           }}
           className={`flex-1 py-3 px-2 text-center font-medium transition-colors flex flex-col items-center space-y-2 ${
             activeTab === 'schedule' && !showPlayer
-              ? 'text-blue-600 dark:text-blue-400 border-b-2 border-[#005BAC] bg-white dark:bg-gray-900'
+              ? 'text-gray-800 dark:text-gray-200 border-b-2 border-gray-500 bg-white dark:bg-gray-900'
               : 'text-gray-600 dark:text-gray-300'
           }`}
         >

--- a/src/components/CalendarDropdown.jsx
+++ b/src/components/CalendarDropdown.jsx
@@ -103,11 +103,11 @@ const CalendarDropdown = ({ value, onChange, gameDates, onOpenSchedule }) => {
                   }}
                   className={`w-8 h-8 flex items-center justify-center rounded-full transition-colors ${
                     selected
-                      ? 'bg-blue-500 text-white'
+                      ? 'bg-gray-600 text-white'
                       : hasGame
-                      ? 'bg-blue-100 dark:bg-blue-900'
+                      ? 'bg-gray-100 dark:bg-gray-900'
                       : ''
-                  } hover:bg-blue-200 dark:hover:bg-blue-700`}
+                  } hover:bg-gray-200 dark:hover:bg-gray-700`}
                 >
                   {date.getDate()}
                 </button>
@@ -119,7 +119,7 @@ const CalendarDropdown = ({ value, onChange, gameDates, onOpenSchedule }) => {
               if (typeof onOpenSchedule === 'function') onOpenSchedule();
               setOpen(false);
             }}
-            className="mt-2 w-full text-sm text-blue-600 hover:text-blue-800"
+            className="mt-2 w-full text-sm text-gray-600 hover:text-gray-800"
           >
             전체 일정 보기
           </button>

--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -62,7 +62,7 @@ const ChantCard = ({
 
     <div className="flex items-center gap-2">
       <button
-        className="flex-1 bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-3 px-4 rounded-xl hover:from-blue-600 hover:to-indigo-700 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
+        className="flex-1 bg-gradient-to-r from-gray-600 to-gray-700 text-white py-3 px-4 rounded-xl hover:from-gray-700 hover:to-gray-800 transition-all flex items-center justify-center gap-2 shadow-md hover:shadow-lg"
         onClick={(e) => {
           e.stopPropagation();
           openPlayer();

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -77,7 +77,7 @@ const ExploreTab = ({
             onClick={() => setExploreTeamFilter('전체')}
             className={`bg-white dark:bg-gray-800 border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 dark:text-gray-100 ${
               exploreTeamFilter === '전체'
-                ? 'ring-2 ring-blue-500 border-transparent'
+                ? 'ring-2 ring-gray-500 border-transparent'
                 : 'border-gray-200'
             }`}
           >
@@ -91,7 +91,7 @@ const ExploreTab = ({
               onClick={() => setExploreTeamFilter(team)}
               className={`bg-white dark:bg-gray-800 border flex flex-col items-center p-2 rounded-lg ${
                 exploreTeamFilter === team
-                  ? 'ring-2 ring-blue-500 border-transparent'
+                  ? 'ring-2 ring-gray-500 border-transparent'
                   : 'border-gray-200'
               }`}
             >
@@ -110,7 +110,7 @@ const ExploreTab = ({
             type="checkbox"
             checked={hasSongOnly}
             onChange={(e) => setHasSongOnly(e.target.checked)}
-            className="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"
+            className="w-4 h-4 text-gray-600 border-gray-300 dark:border-gray-600 rounded"
           />
           <label htmlFor="songOnly" className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
             응원가 있는 선수만
@@ -120,7 +120,7 @@ const ExploreTab = ({
             type="checkbox"
             checked={hasBatterOnly}
             onChange={(e) => setHasBatterOnly(e.target.checked)}
-            className="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded ml-4"
+            className="w-4 h-4 text-gray-600 border-gray-300 dark:border-gray-600 rounded ml-4"
           />
           <label htmlFor="batterOnly" className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
             타자만
@@ -130,17 +130,17 @@ const ExploreTab = ({
     </div>
     {/* 통계 카드 */}
     <div className="grid grid-cols-3 gap-3 mb-4">
-      <div className="bg-gradient-to-br from-indigo-500 via-indigo-600 to-indigo-700 rounded-xl p-3 text-white shadow">
+      <div className="bg-gradient-to-br from-gray-600 via-gray-700 to-gray-800 rounded-xl p-3 text-white shadow">
         <h3 className="text-lg font-bold">{totalPlayers}</h3>
         <p className="text-xs text-indigo-100 mt-1">총 선수</p>
       </div>
-      <div className="bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 rounded-xl p-3 text-white shadow">
+      <div className="bg-gradient-to-br from-gray-600 via-gray-700 to-gray-800 rounded-xl p-3 text-white shadow">
         <h3 className="text-lg font-bold">{totalChants}</h3>
-        <p className="text-xs text-blue-100 mt-1">총 응원가</p>
+        <p className="text-xs text-gray-200 mt-1">총 응원가</p>
       </div>
-      <div className="bg-gradient-to-br from-emerald-500 via-emerald-600 to-emerald-700 rounded-xl p-3 text-white shadow">
+      <div className="bg-gradient-to-br from-gray-600 via-gray-700 to-gray-800 rounded-xl p-3 text-white shadow">
         <h3 className="text-lg font-bold">{filteredChants.length}</h3>
-        <p className="text-xs text-emerald-100 mt-1">검색 결과</p>
+        <p className="text-xs text-gray-200 mt-1">검색 결과</p>
       </div>
     </div>
     {/* 응원가 목록 */}
@@ -162,7 +162,7 @@ const ExploreTab = ({
               setSelectedDate(`${yyyy}-${mm}-${dd}`);
               fetchJsonData();
             }}
-            className="p-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+            className="p-1 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
           </button>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -8,7 +8,7 @@ const Footer = () => (
     <br />
     <a
       href="mailto:jikgwangaza@gmail.com?subject=Bug%20Report"
-      className="underline hover:text-blue-600"
+      className="underline hover:text-gray-600"
     >
       오류 제보하기
     </a>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -41,14 +41,14 @@ const LineupTab = ({
         <div className="flex items-center gap-2">
           <button
             onClick={handleShareLineup}
-            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-1 text-gray-600 hover:text-gray-800 transition-colors"
           >
             <Share2 className="w-4 h-4" />
             공유하기
           </button>
           <button
             onClick={fetchJsonData}
-            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-2 text-gray-600 hover:text-gray-800 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -82,7 +82,7 @@ const LineupTab = ({
 
       {loading ? (
         <div className="text-center py-8">
-          <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-blue-500" />
+          <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-gray-600" />
           <p className="text-gray-600">데이터를 불러오는 중...</p>
         </div>
       ) : currentGame ? (
@@ -231,7 +231,7 @@ const LineupTab = ({
                       setSelectedDate(dateOnly);
                     }
                   }}
-                  className="mt-4 bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors"
+                  className="mt-4 bg-gray-600 text-white px-6 py-2 rounded-lg hover:bg-gray-700 transition-colors"
                 >
                   최근 라인업 보러가기
                 </button>
@@ -300,7 +300,7 @@ const LineupTab = ({
                 setSelectedDate(dateOnly);
               }
             }}
-            className="mt-4 bg-blue-500 text-white px-6 py-2 rounded-lg hover:bg-blue-600 transition-colors"
+            className="mt-4 bg-gray-600 text-white px-6 py-2 rounded-lg hover:bg-gray-700 transition-colors"
           >
             최근 라인업 보러가기
           </button>

--- a/src/components/LyricsSection.jsx
+++ b/src/components/LyricsSection.jsx
@@ -12,7 +12,7 @@ const LyricsSection = ({ chant, hasVideo, defaultExpanded = false }) => {
         <div>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors mb-3 font-medium"
+          className="flex items-center gap-2 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 transition-colors mb-3 font-medium"
           >
             <Music className="w-4 h-4" />
             {isExpanded ? '가사 숨기기' : '가사 보기'}

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -44,7 +44,7 @@ const PlayerCard = ({
       <div className="flex items-center justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-3">
-            <span className="bg-blue-500 text-white rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg">
+            <span className="bg-gray-600 text-white rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg">
               {player.order || index + 1}
             </span>
             <div>
@@ -64,7 +64,7 @@ const PlayerCard = ({
                 e.stopPropagation();
                 openPlayer();
               }}
-              className="bg-blue-500 text-white p-2 rounded-full hover:bg-blue-600 transition-colors"
+              className="bg-gray-600 text-white p-2 rounded-full hover:bg-gray-700 transition-colors"
               aria-label={`${player.playerName} 응원가 재생`}
             >
               <Play className="w-4 h-4" />

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -89,7 +89,7 @@ const PlayerSongsCard = ({
             openPlayer();
           }}
         >
-          <Play className="w-4 h-4 text-blue-600" />
+          <Play className="w-4 h-4 text-gray-600" />
           <span className="font-medium text-gray-900 dark:text-gray-100">응원가 재생</span>
         </button>
       )}

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -94,7 +94,7 @@ const PlayerTab = ({
           {/* 타순 정보 (라인업 모드에서만) */}
           {playSource === 'lineup' &&
             getBattingOrder(currentChant.order, getDisplayPosition()) && (
-              <p className="text-sm text-blue-600 mb-2 font-medium">
+              <p className="text-sm text-gray-600 mb-2 font-medium">
                 {getBattingOrder(currentChant.order, getDisplayPosition())}
               </p>
             )}
@@ -109,7 +109,7 @@ const PlayerTab = ({
               </p>
               <button
                 onClick={handleInfoRequest}
-                className="text-sm text-blue-500 underline"
+                className="text-sm text-gray-600 underline"
               >
                 정보 요청하기
               </button>
@@ -173,7 +173,7 @@ const PlayerTab = ({
               onClick={() => setSongIndex(idx)}
               className={`px-3 py-1 rounded-full text-sm whitespace-nowrap ${
                 songIndex === idx
-                  ? 'bg-blue-500 text-white'
+                  ? 'bg-gray-600 text-white'
                   : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200'
               }`}
             >

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -44,7 +44,7 @@ const ScheduleTab = ({
             onClick={() => setLocationFilter(opt)}
             className={`bg-white dark:bg-gray-800 border px-3 py-1 rounded-lg text-xs font-medium text-gray-900 dark:text-gray-100 ${
               locationFilter === opt
-                ? 'ring-2 ring-blue-500 border-transparent'
+                ? 'ring-2 ring-gray-500 border-transparent'
                 : 'border-gray-200'
             }`}
           >

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -23,7 +23,7 @@ const ScrollToTopButton = () => {
   return (
     <button
       onClick={scrollToTop}
-      className={`fixed bottom-6 right-6 p-3 bg-blue-500 text-white rounded-full shadow-lg transition-opacity ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      className={`fixed bottom-6 right-6 p-3 bg-gray-600 text-white rounded-full shadow-lg transition-opacity ${visible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
       aria-label="맨 위로"
     >
       <ChevronUp className="w-5 h-5" />

--- a/src/components/StartingPitcherCard.jsx
+++ b/src/components/StartingPitcherCard.jsx
@@ -25,7 +25,7 @@ const StartingPitcherCard = ({
   return (
     <div
       onClick={openPlayer}
-      className="p-4 rounded-xl border-2 transition-all cursor-pointer border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900 hover:border-blue-300 dark:hover:border-blue-600 mb-4 w-full"
+      className="p-4 rounded-xl border-2 transition-all cursor-pointer border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 mb-4 w-full"
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -38,7 +38,7 @@ const StartingPitcherCard = ({
             </p>
           )}
         </div>
-        <span className="bg-blue-500 text-white text-xs font-medium px-2 py-1 rounded-full">
+        <span className="bg-gray-600 text-white text-xs font-medium px-2 py-1 rounded-full">
           선발투수
         </span>
       </div>

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -107,7 +107,7 @@ const TeamChantsTab = ({
               setSelectedDate(`${yyyy}-${mm}-${dd}`);
               fetchJsonData();
             }}
-            className="p-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-full"
+            className="p-2 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 transition-colors hover:bg-gray-50 dark:hover:bg-gray-900/30 rounded-full"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -131,7 +131,7 @@ const TeamChantsTab = ({
           onChange={(e) => setSearchTerm(e.target.value)}
           placeholder="응원가 제목이나 가사로 검색하세요"
           aria-label="응원가 검색"
-          className="w-full pl-9 pr-9 py-2 border border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 focus:ring-2 focus:ring-blue-500"
+          className="w-full pl-9 pr-9 py-2 border border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 focus:ring-2 focus:ring-gray-500"
         />
       </div>
 
@@ -165,14 +165,14 @@ const TeamChantsTab = ({
 
       {loading ? (
         <div className="text-center py-8">
-          <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-blue-500" />
+          <RefreshCw className="w-8 h-8 animate-spin mx-auto mb-4 text-gray-600" />
           <p className="text-gray-600 dark:text-gray-300">팀 응원가를 불러오는 중...</p>
         </div>
       ) : activeChant ? (
         <div className="space-y-4">
           <button
             onClick={() => setActiveChantId(null)}
-            className="text-blue-600 hover:text-blue-800 transition-colors mb-4"
+            className="text-gray-600 hover:text-gray-800 transition-colors mb-4"
           >
             목록으로
           </button>


### PR DESCRIPTION
## Summary
- remove vivid blue accent color from UI components
- use gray scheme for scroll-to-top button, menus and cards
- switch app header and loading background to subtle gray gradient
- keep team color borders but drop bright blue outlines

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686892dbf1348331aa23bfcce6878854