### PR TITLE
Fix dark mode visibility for buttons and logos

### DIFF
--- a/src/components/ChantCard.jsx
+++ b/src/components/ChantCard.jsx
@@ -37,7 +37,7 @@ const ChantCard = ({
               <img
                 src={getTeamInfo(chant.team).logo}
                 alt={chant.team}
-                className="w-4 h-4 object-contain"
+                className="team-logo w-4 h-4 object-contain"
               />
             )}
             <span className="font-medium px-2 py-1 rounded-full text-xs" style={{

--- a/src/components/ExploreTab.jsx
+++ b/src/components/ExploreTab.jsx
@@ -99,7 +99,7 @@ const ExploreTab = ({
               <img
                 src={getTeamInfo(team).logo}
                 alt={team}
-                className="w-8 h-8 object-contain mb-1"
+                className="team-logo w-8 h-8 object-contain mb-1"
               />
               <span className="text-xs text-gray-900 dark:text-gray-100">{team}</span>
             </button>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -42,14 +42,14 @@ const LineupTab = ({
         <div className="flex items-center gap-2">
           <button
             onClick={handleShareLineup}
-            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <Share2 className="w-4 h-4" />
             공유하기
           </button>
           <button
             onClick={fetchJsonData}
-            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="flex items-center gap-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -96,7 +96,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.away).logo}
                       alt={currentGame.away}
-                      className="w-5 h-5 object-contain"
+                      className="team-logo w-5 h-5 object-contain"
                     />
                   )}
                   <span className="font-semibold">{currentGame.away}</span>
@@ -111,7 +111,7 @@ const LineupTab = ({
                     <img
                       src={getTeamInfo(currentGame.home).logo}
                       alt={currentGame.home}
-                      className="w-5 h-5 object-contain"
+                      className="team-logo w-5 h-5 object-contain"
                     />
                   )}
                   <span className="font-semibold">{currentGame.home}</span>

--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -45,7 +45,10 @@ const PlayerCard = ({
       <div className="flex items-center justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-3">
-            <span className="bg-blue-500 text-white rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg">
+            <span
+              className="text-white rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg"
+              style={{ backgroundColor: `${getTeamInfo(selectedTeam).color}cc` }}
+            >
               {player.order || index + 1}
             </span>
             <div>

--- a/src/components/PlayerSongsCard.jsx
+++ b/src/components/PlayerSongsCard.jsx
@@ -43,7 +43,7 @@ const PlayerSongsCard = ({
                 <img
                   src={getTeamInfo(first.team).logo}
                   alt={first.team}
-                  className="w-4 h-4 object-contain"
+                  className="team-logo w-4 h-4 object-contain"
                 />
               )}
               <span

--- a/src/components/PlayerTab.jsx
+++ b/src/components/PlayerTab.jsx
@@ -125,7 +125,7 @@ const PlayerTab = ({
                 <img
                   src={getTeamInfo(getDisplayTeam()).logo}
                   alt={getDisplayTeam()}
-                  className="w-5 h-5 object-contain"
+                  className="team-logo w-5 h-5 object-contain"
                 />
               )}
               <span className="font-semibold" style={{ color: getTeamInfo(getDisplayTeam()).color }}>

--- a/src/components/RankingTab.jsx
+++ b/src/components/RankingTab.jsx
@@ -53,7 +53,7 @@ const RankingTab = ({ teamRanks, rankUpdatedAt }) => {
                     <img
                       src={getTeamInfo(t.team).logo}
                       alt={t.team}
-                      className="w-5 h-5 object-contain"
+                      className="team-logo w-5 h-5 object-contain"
                     />
                   )}
                   <span>{t.team}</span>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -83,7 +83,7 @@ const ScheduleTab = ({
                 <img
                   src={getTeamInfo(game.away).logo}
                   alt={game.away}
-                  className="w-5 h-5 object-contain"
+                  className="team-logo w-5 h-5 object-contain"
                 />
               )}
               <span className="font-medium">{game.away}</span>
@@ -93,7 +93,7 @@ const ScheduleTab = ({
                 <img
                   src={getTeamInfo(game.home).logo}
                   alt={game.home}
-                  className="w-5 h-5 object-contain"
+                  className="team-logo w-5 h-5 object-contain"
                 />
               )}
               <span className="font-medium">{game.home}</span>

--- a/src/components/StartingPitcherCard.jsx
+++ b/src/components/StartingPitcherCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getTeamInfo } from '../utils/team';
 
 const StartingPitcherCard = ({
   pitcher,
@@ -39,7 +40,10 @@ const StartingPitcherCard = ({
             </p>
           )}
         </div>
-        <span className="bg-blue-500 text-white text-xs font-medium px-2 py-1 rounded-full">
+        <span
+          className="text-white text-xs font-medium px-2 py-1 rounded-full"
+          style={{ backgroundColor: `${getTeamInfo(selectedTeam).color}cc` }}
+        >
           선발투수
         </span>
       </div>

--- a/src/components/TeamChantsTab.jsx
+++ b/src/components/TeamChantsTab.jsx
@@ -172,7 +172,7 @@ const TeamChantsTab = ({
         <div className="space-y-4">
           <button
             onClick={() => setActiveChantId(null)}
-            className="text-blue-600 hover:text-blue-800 transition-colors mb-4"
+            className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors mb-4"
           >
             목록으로
           </button>
@@ -222,7 +222,7 @@ const TeamChantsTab = ({
                 <img
                   src={getTeamInfo(selectedTeam).logo}
                   alt={selectedTeam}
-                  className="w-5 h-5 object-contain"
+                  className="team-logo w-5 h-5 object-contain"
                 />
               ) : (
                 <Trophy className="w-5 h-5" style={{ color: getTeamInfo(selectedTeam).color }} />

--- a/src/components/TeamSelectModal.jsx
+++ b/src/components/TeamSelectModal.jsx
@@ -19,7 +19,7 @@ const TeamSelectModal = ({ onSelect }) => {
                 <img
                   src={getTeamInfo(team).logo}
                   alt={team}
-                  className="w-10 h-10 object-contain"
+                  className="team-logo w-10 h-10 object-contain"
                 />
               )}
               <span className="text-xs mt-1 whitespace-nowrap">

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,6 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.team-logo { @apply bg-white dark:bg-white rounded p-0.5; }
+


### PR DESCRIPTION
## Summary
- ensure team logos stay visible on dark backgrounds
- brighten blue button styles in dark mode
- color lineup numbers with team color

## Testing
- `CI=true npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868978a38448331ae46f308d811ca7d