### PR TITLE
Fix getTeamInfo not defined

### DIFF
--- a/src/components/PlayerCard.jsx
+++ b/src/components/PlayerCard.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Play } from "lucide-react";
-import { getPositionKorean } from "../utils/team";
+import { getPositionKorean, getTeamInfo } from "../utils/team";
 
 const PlayerCard = ({
   player,


### PR DESCRIPTION
## Summary
- fix `getTeamInfo` missing import

## Testing
- `npm install` *(fails: network restricted)*
- `npm test` *(fails: react-scripts not found due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_6868b12be2708331901bf2355ce82741