### PR TITLE
Disable unused English name support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,9 +67,6 @@ const JikgwanGaja = () => {
     if (stored) return stored === 'dark';
     return window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
-  const [language, setLanguage] = useState(() =>
-    localStorage.getItem('language') || 'ko'
-  );
   const [selectedDate, setSelectedDate] = useState(() => {
     const today = new Date();
     const yyyy = today.getFullYear();
@@ -98,12 +95,7 @@ const JikgwanGaja = () => {
     setSelectedGameCode(null);
   }, [selectedDate, selectedTeam]);
 
-  const getDisplayName = (name) => {
-    if (language === 'en') {
-      return playerNameEnMap[name] || name;
-    }
-    return name;
-  };
+  const getDisplayName = (name) => name;
   
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -171,9 +163,6 @@ const JikgwanGaja = () => {
     localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
   }, [isDarkMode]);
 
-  useEffect(() => {
-    localStorage.setItem('language', language);
-  }, [language]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -211,8 +200,6 @@ const JikgwanGaja = () => {
     gameLineups,
     teamChants,
     kboPlayers,
-    kboPlayersEn,
-    playerNameEnMap,
     rawSongs,
     loading,
     error,
@@ -776,10 +763,7 @@ const getSortedChants = () => {
         <div>
           <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">직관가자</h1>
           <p className="text-sm text-gray-500 dark:text-gray-300">
-            {language === 'en'
-              ? getTeamInfo(selectedTeam).fullNameEn
-              : getTeamInfo(selectedTeam).fullName}{' '}
-            • {formatDateKorean(selectedDate)}
+            {getTeamInfo(selectedTeam).fullName} • {formatDateKorean(selectedDate)}
           </p>
         </div>
       </div>
@@ -828,7 +812,6 @@ const getSortedChants = () => {
                 // ignore write errors
               }
             }}
-            language={language}
           />
         </div>
      </div>

--- a/src/components/TeamDropdown.jsx
+++ b/src/components/TeamDropdown.jsx
@@ -4,7 +4,7 @@ import { getTeamInfo } from '../utils/team';
 
 const teams = ['KIA','두산','LG','삼성','롯데','SSG','키움','한화','NC','KT'];
 
-const TeamDropdown = ({ value, onChange, language = 'ko' }) => {
+const TeamDropdown = ({ value, onChange }) => {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
 
@@ -24,7 +24,7 @@ const TeamDropdown = ({ value, onChange, language = 'ko' }) => {
         onClick={() => setOpen(!open)}
         className="flex items-center bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm rounded-xl px-4 py-2 border border-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-600"
       >
-        {language === 'en' ? getTeamInfo(value).fullNameEn : getTeamInfo(value).fullName}
+        {getTeamInfo(value).fullName}
         <ChevronDown className="w-4 h-4 ml-2" />
       </button>
       {open && (
@@ -38,7 +38,7 @@ const TeamDropdown = ({ value, onChange, language = 'ko' }) => {
               }}
               className="w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
             >
-              {language === 'en' ? getTeamInfo(team).fullNameEn : getTeamInfo(team).fullName}
+              {getTeamInfo(team).fullName}
             </button>
           ))}
         </div>

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -96,8 +96,6 @@ const useKboData = () => {
   const [gameLineups, setGameLineups] = useState([]);
   const [teamChants, setTeamChants] = useState([]);
   const [kboPlayers, setKboPlayers] = useState([]);
-  const [kboPlayersEn, setKboPlayersEn] = useState([]);
-  const [playerNameEnMap, setPlayerNameEnMap] = useState({});
   const [rawSongs, setRawSongs] = useState([]);
   const [teamRanks, setTeamRanks] = useState([]);
   const [teamRankTime, setTeamRankTime] = useState(null);
@@ -121,14 +119,13 @@ const useKboData = () => {
     try {
       const base = process.env.PUBLIC_URL || '';
 
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, kboPlayersEnData] = await Promise.all([
+      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
         fetchSafeJson(`${base}/data/kbo_crawler_data/index.json`, null),
         fetchSafeJson(`${base}/data/teamChants.json`, []),
         fetchSafeJson(`${base}/data/kboPlayers.json`, []),
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
         fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
-        fetchSafeJson(`${base}/data/kboPlayersEn.json`, []),
       ]);
 
       console.log('로드된 데이터:', {
@@ -137,20 +134,11 @@ const useKboData = () => {
         teamChantsCount: teamChantsData?.length,
         kboPlayersCount: kboPlayersData?.length,
         teamRankCount: teamRankData?.results?.length,
-        kboPlayersEnCount: kboPlayersEnData?.length,
       });
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
-      const parsedKboPlayersEn = Array.isArray(kboPlayersEnData) ? kboPlayersEnData : [];
       setKboPlayers(parsedKboPlayers);
-      setKboPlayersEn(parsedKboPlayersEn);
-      const map = {};
-      parsedKboPlayersEn.forEach(p => {
-        if (p.playerName && p.playerNameEn) {
-          map[p.playerName] = p.playerNameEn;
-        }
-      });
-      setPlayerNameEnMap(map);
+
       setRawSongs(Array.isArray(songsData) ? songsData : []);
 
       // 선수 응원가 데이터 처리 - KBO 선수 기준으로 구성
@@ -456,8 +444,6 @@ const useKboData = () => {
     gameLineups,
     teamChants,
     kboPlayers,
-    kboPlayersEn,
-    playerNameEnMap,
     rawSongs,
     loading,
     error,


### PR DESCRIPTION
## Summary
- drop `language` state and English name mapping
- remove English options from TeamDropdown
- stop fetching English player name data

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b24935288331807431ab47a54ddb