### PR TITLE
Fix notch overlap for mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/jikgwangaza_logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="직관 초보도 직관가자와 함께라면 야구장 처음인 나도 응원 고수! 매일 업데이트되는 선발 라인업과 응원가 ⚾ KBO 10개 구단 완벽 지원" />
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,14 @@
 
 body {
   margin: 0;
+  padding-top: constant(safe-area-inset-top); /* iOS < 11.2 */
+  padding-top: env(safe-area-inset-top);
+  padding-right: constant(safe-area-inset-right);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: constant(safe-area-inset-left);
+  padding-left: env(safe-area-inset-left);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
## Summary
- add `viewport-fit=cover` to meta viewport tag
- apply safe area insets in global CSS

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e97cadfe083318ccb101acf348dcc