### PR TITLE
Keep tab navigation visible while scrolling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -826,7 +826,7 @@ const getSortedChants = () => {
      </div>
 
      {/* 탭 네비게이션 */}
-      <div className="flex bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700">
+      <div className="sticky top-0 z-20 flex bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700">
         <button
           onClick={() => {
             setActiveTab('lineup');


### PR DESCRIPTION
## Summary
- ensure the tab bar stays visible by making it sticky

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f726f17208331b2ad0d00fe0217b6