### PR TITLE
Fix display name to 직관가자

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ On first visit the site asks you to choose your favorite team. The choice is sav
 in `localStorage` under `favoriteTeam` so it persists across sessions. If you want
 to pick again, clear your browser storage or remove that key.
 
-© 2025 Jikgwangaza. All rights reserved.
+© 2025 직관가자. All rights reserved.
 Created and maintained by Sumin Lee.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Jikgwangaza</string>
-    <string name="title_activity_main">Jikgwangaza</string>
+    <string name="app_name">직관가자</string>
+    <string name="title_activity_main">직관가자</string>
     <string name="package_name">com.jikgwangaza.app</string>
     <string name="custom_url_scheme">com.jikgwangaza.app</string>
 </resources>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleDisplayName</key>
-	<string>Jikgwangaza</string>
+       <key>CFBundleDisplayName</key>
+       <string>직관가자</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Footer = () => (
   <footer className="text-center text-xs text-gray-500 dark:text-gray-400 py-6">
-    © 2025 Jikgwangaza. All rights reserved.
+    © 2025 직관가자. All rights reserved.
     <br />
     Created and maintained by Sumin Lee.
     <br />


### PR DESCRIPTION
## Summary
- update iOS display name in Info.plist
- update Android app_name in strings.xml
- fix footer copyright text
- adjust README copyright

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb57e788883318bb37d58cbeba00f