### PR TITLE
Add iOS icon update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ npm run build # build for production
 
 Running these commands requires **Node.js 20 or later**.
 
+## Updating the iOS app icon
+
+The master icon images live under `public/AppIcon/Assets.xcassets/AppIcon.appiconset`.
+Run the following command to copy them into the iOS project:
+
+```bash
+npm run update-ios-icons
+```
+
+After copying, rebuild the Xcode project to see the new logo.
+
 ## Handling multiple songs per player
 
 Some players have more than one walk‑up song. When the app opens a player

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "build-lineup-index": "node scripts/generateLineupIndex.js",
-    "update-song-mapping": "node scripts/updatePlayerSongTeams.js"
+    "update-song-mapping": "node scripts/updatePlayerSongTeams.js",
+    "update-ios-icons": "node scripts/updateIosIcon.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/updateIosIcon.js
+++ b/scripts/updateIosIcon.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, '..', 'public', 'AppIcon', 'Assets.xcassets', 'AppIcon.appiconset');
+const destDir = path.join(__dirname, '..', 'ios', 'App', 'App', 'Assets.xcassets', 'AppIcon.appiconset');
+
+function copyIcons() {
+  fs.cpSync(srcDir, destDir, { recursive: true });
+  console.log(`Copied iOS icons from ${srcDir} to ${destDir}`);
+}
+
+if (require.main === module) {
+  copyIcons();
+}
+
+module.exports = copyIcons;


### PR DESCRIPTION
## Summary
- add helper script to copy iOS app icon assets
- document how to update the iOS icon
- expose `npm run update-ios-icons` in package.json

## Testing
- `node scripts/updateIosIcon.js`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687099245678833186bb166b30a02eb1