### PR TITLE
Add Android icon update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,17 @@ npm run build # build for production
 
 Running these commands requires **Node.js 20 or later**.
 
-## Updating the iOS app icon
+## Updating native app icons
 
-The master icon images live under `public/AppIcon/Assets.xcassets/AppIcon.appiconset`.
-Run the following command to copy them into the iOS project:
+All master icon images live in `public/AppIcon`. Use the following commands to
+copy them into the native projects:
 
 ```bash
 npm run update-ios-icons
+npm run update-android-icons
 ```
 
-After copying, rebuild the Xcode project to see the new logo.
+After copying, rebuild the Xcode or Android project to see the new logos.
 
 ## Handling multiple songs per player
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "eject": "react-scripts eject",
     "build-lineup-index": "node scripts/generateLineupIndex.js",
     "update-song-mapping": "node scripts/updatePlayerSongTeams.js",
-    "update-ios-icons": "node scripts/updateIosIcon.js"
+    "update-ios-icons": "node scripts/updateIosIcon.js",
+    "update-android-icons": "node scripts/updateAndroidIcons.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/updateAndroidIcons.js
+++ b/scripts/updateAndroidIcons.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcBase = path.join(__dirname, '..', 'public', 'AppIcon', 'android');
+const destBase = path.join(__dirname, '..', 'android', 'app', 'src', 'main', 'res');
+const mipmapDirs = ['mipmap-hdpi', 'mipmap-mdpi', 'mipmap-xhdpi', 'mipmap-xxhdpi', 'mipmap-xxxhdpi'];
+
+function copyIcons() {
+  mipmapDirs.forEach(dir => {
+    const src = path.join(srcBase, dir, 'ic_launcher.png');
+    const destDir = path.join(destBase, dir);
+    const dest = path.join(destDir, 'ic_launcher.png');
+    if (fs.existsSync(src) && fs.existsSync(destDir)) {
+      fs.copyFileSync(src, dest);
+    }
+  });
+  console.log(`Copied Android icons from ${srcBase} to ${destBase}`);
+}
+
+if (require.main === module) {
+  copyIcons();
+}
+
+module.exports = copyIcons;


### PR DESCRIPTION
## Summary
- automate copying icons into Android project
- document how to update iOS and Android icons

## Testing
- `npm run update-android-icons --silent`
- `npm run update-ios-icons --silent`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709b95a8c083319596713df379c3f1