### PR TITLE
Fix sticky tab bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -103,6 +103,19 @@ const JikgwanGaja = () => {
   const [immediateSearch, setImmediateSearch] = useState('');
   const searchRef = useRef('');
   const playerRef = useRef(null);
+  const headerRef = useRef(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useEffect(() => {
+    const updateHeaderHeight = () => {
+      if (headerRef.current) {
+        setHeaderHeight(headerRef.current.offsetHeight);
+      }
+    };
+    updateHeaderHeight();
+    window.addEventListener('resize', updateHeaderHeight);
+    return () => window.removeEventListener('resize', updateHeaderHeight);
+  }, []);
 
   // URL과 상태를 동기화한다
   useEffect(() => {
@@ -738,7 +751,7 @@ const getSortedChants = () => {
  return (
   <div className="max-w-md mx-auto bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700 min-h-screen flex flex-col dark:text-gray-100">
      {/* 헤더 */}
-    <div className="sticky top-0 z-30 bg-white/90 backdrop-blur-xl border-b shadow-sm text-gray-900 p-4 border-gray-100 dark:bg-gray-800/90 dark:text-gray-100 dark:border-gray-700 overflow-visible">
+    <div ref={headerRef} className="sticky top-0 z-30 bg-white/90 backdrop-blur-xl border-b shadow-sm text-gray-900 p-4 border-gray-100 dark:bg-gray-800/90 dark:text-gray-100 dark:border-gray-700 overflow-visible">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
         <div 
@@ -822,7 +835,10 @@ const getSortedChants = () => {
      </div>
 
      {/* 탭 네비게이션 */}
-      <div className="sticky top-0 z-20 flex bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700">
+      <div
+        className="sticky z-20 flex bg-gray-50 border-b dark:bg-gray-800 dark:border-gray-700"
+        style={{ top: headerHeight }}
+      >
         <button
           onClick={() => {
             setActiveTab('lineup');


### PR DESCRIPTION
## Summary
- keep tab bar visible below the header when scrolling

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873742f9c2c8331b03497017fe69b28