### PR TITLE
Add All-Star data integration

### DIFF
--- a/public/data/allStar2025.json
+++ b/public/data/allStar2025.json
@@ -1,0 +1,78 @@
+{
+  "dream": {
+    "best": [
+      {"position":"투수","role":"선발","playerName":"박세웅","team":"롯데"},
+      {"position":"투수","role":"중간","playerName":"배찬승","team":"삼성"},
+      {"position":"투수","role":"마무리","playerName":"김원중","team":"롯데"},
+      {"position":"포수","playerName":"강민호","team":"삼성"},
+      {"position":"1루수","playerName":"디아즈","team":"삼성"},
+      {"position":"2루수","playerName":"류지혁","team":"삼성"},
+      {"position":"3루수","playerName":"최정","team":"SSG"},
+      {"position":"유격수","playerName":"전민재","team":"롯데"},
+      {"position":"외야수","playerName":"구자욱","team":"삼성"},
+      {"position":"외야수","playerName":"김지찬","team":"삼성"},
+      {"position":"외야수","playerName":"레이예스","team":"롯데"},
+      {"position":"지명타자","playerName":"전준우","team":"롯데"}
+    ],
+    "coachPicks": [
+      {"position":"투수","playerName":"이호성","team":"삼성"},
+      {"position":"투수","playerName":"김택연","team":"두산"},
+      {"position":"투수","playerName":"박치국","team":"두산"},
+      {"position":"투수","playerName":"박영현","team":"KT"},
+      {"position":"투수","playerName":"우규민","team":"KT"},
+      {"position":"투수","playerName":"이로운","team":"SSG"},
+      {"position":"투수","playerName":"조병현","team":"SSG"},
+      {"position":"포수","playerName":"장성우","team":"KT"},
+      {"position":"포수","playerName":"조형우","team":"SSG"},
+      {"position":"내야수","playerName":"오명진","team":"두산"},
+      {"position":"내야수","playerName":"권동진","team":"KT"},
+      {"position":"외야수","playerName":"배정대","team":"KT"},
+      {"position":"외야수","playerName":"안현민","team":"KT"}
+    ],
+    "coaches": [
+      {"role":"감독","name":"박진만","team":"삼성"},
+      {"role":"코치","name":"조성환","team":"두산"},
+      {"role":"코치","name":"이강철","team":"KT"},
+      {"role":"코치","name":"이숭용","team":"SSG"},
+      {"role":"코치","name":"김태형","team":"롯데"}
+    ]
+  },
+  "nanum": {
+    "best": [
+      {"position":"투수","role":"선발","playerName":"폰세","team":"한화"},
+      {"position":"투수","role":"중간","playerName":"박상원","team":"한화"},
+      {"position":"투수","role":"마무리","playerName":"김서현","team":"한화"},
+      {"position":"포수","playerName":"박동원","team":"LG"},
+      {"position":"1루수","playerName":"채은성","team":"한화"},
+      {"position":"2루수","playerName":"박민우","team":"NC"},
+      {"position":"3루수","playerName":"송성문","team":"키움"},
+      {"position":"유격수","playerName":"박찬호","team":"KIA"},
+      {"position":"외야수","playerName":"박건우","team":"NC"},
+      {"position":"외야수","playerName":"이주형","team":"키움"},
+      {"position":"외야수","playerName":"박해민","team":"LG"},
+      {"position":"지명타자","playerName":"문현빈","team":"한화"}
+    ],
+    "coachPicks": [
+      {"position":"투수","playerName":"성영탁","team":"KIA"},
+      {"position":"투수","playerName":"최지민","team":"KIA"},
+      {"position":"투수","playerName":"김영우","team":"LG"},
+      {"position":"투수","playerName":"박명근","team":"LG"},
+      {"position":"투수","playerName":"배재환","team":"NC"},
+      {"position":"투수","playerName":"주승우","team":"키움"},
+      {"position":"투수","playerName":"하영민","team":"키움"},
+      {"position":"포수","playerName":"김태군","team":"KIA"},
+      {"position":"포수","playerName":"김형준","team":"NC"},
+      {"position":"내야수","playerName":"이도윤","team":"한화"},
+      {"position":"내야수","playerName":"김주원","team":"NC"},
+      {"position":"외야수","playerName":"김현수","team":"LG"},
+      {"position":"외야수","playerName":"김호령","team":"KIA"}
+    ],
+    "coaches": [
+      {"role":"감독","name":"이범호","team":"KIA"},
+      {"role":"코치","name":"염경엽","team":"LG"},
+      {"role":"코치","name":"김경문","team":"한화"},
+      {"role":"코치","name":"이호준","team":"NC"},
+      {"role":"코치","name":"홍원기","team":"키움"}
+    ]
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -219,6 +219,7 @@ const JikgwanGaja = () => {
     fetchJsonData,
     teamRanks,
     teamRankTime,
+    allStarData,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -962,6 +963,7 @@ const getSortedChants = () => {
                 handleShareLineup={handleShareLineup}
                 teamRanks={teamRanks}
                 getDisplayName={getDisplayName}
+                allStarData={allStarData}
               />
             )}
             {activeTab === 'teamChants' && (

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PlayerCard from './PlayerCard';
 import StartingPitcherCard from './StartingPitcherCard';
 import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
@@ -28,12 +28,82 @@ const LineupTab = ({
   handleShareLineup,
   teamRanks,
   getDisplayName,
+  allStarData,
 }) => {
   const currentGame = getCurrentGame();
+  const [allStarTeam, setAllStarTeam] = useState('dream');
+  const isAllStarDay = selectedDate === '2025-07-12';
   const getRank = (team) => {
     const r = teamRanks?.find((t) => t.team === team);
     return r ? `${r.rank}위` : '';
   };
+
+  const renderAllStarSection = (title, items) => (
+    <div className="mb-4">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      <ul className="space-y-1">
+        {items.map((p, idx) => (
+          <li
+            key={`${title}_${idx}`}
+            className="flex justify-between border-b pb-1 text-sm"
+          >
+            <span>
+              {p.position || p.role}
+              {p.role && p.position ? `(${p.position})` : ''}
+            </span>
+            <span>{p.playerName || p.name}</span>
+            <span className="text-gray-500">{p.team}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  if (isAllStarDay) {
+    if (!allStarData) {
+      return <p className="text-center py-8">올스타전 데이터가 없습니다.</p>;
+    }
+
+    const roster =
+      allStarTeam === 'dream' ? allStarData.dream : allStarData.nanum;
+    const teamLabel = allStarTeam === 'dream' ? '드림 올스타' : '나눔 올스타';
+
+    return (
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <button
+            onClick={() => setAllStarTeam('dream')}
+            className={`flex-1 py-2 rounded-lg text-sm font-medium ${
+              allStarTeam === 'dream'
+                ? 'bg-blue-600 text-white'
+                : 'bg-white dark:bg-gray-800 border border-gray-200'
+            }`}
+          >
+            드림
+          </button>
+          <button
+            onClick={() => setAllStarTeam('nanum')}
+            className={`flex-1 py-2 rounded-lg text-sm font-medium ${
+              allStarTeam === 'nanum'
+                ? 'bg-blue-600 text-white'
+                : 'bg-white dark:bg-gray-800 border border-gray-200'
+            }`}
+          >
+            나눔
+          </button>
+        </div>
+        <h2 className="text-xl font-bold text-gray-800 dark:text-gray-100">
+          2025 KBO 올스타전 {teamLabel}
+        </h2>
+        {renderAllStarSection('BEST 12', roster.best)}
+        {renderAllStarSection('감독 추천선수', roster.coachPicks)}
+        {renderAllStarSection(
+          '올스타 코칭스태프',
+          roster.coaches.map((c) => ({ ...c }))
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -99,6 +99,7 @@ const useKboData = () => {
   const [rawSongs, setRawSongs] = useState([]);
   const [teamRanks, setTeamRanks] = useState([]);
   const [teamRankTime, setTeamRankTime] = useState(null);
+  const [allStarData, setAllStarData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -119,13 +120,14 @@ const useKboData = () => {
     try {
       const base = process.env.PUBLIC_URL || '';
 
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData] = await Promise.all([
+      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, allStar] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
         fetchSafeJson(`${base}/data/kbo_crawler_data/index.json`, null),
         fetchSafeJson(`${base}/data/teamChants.json`, []),
         fetchSafeJson(`${base}/data/kboPlayers.json`, []),
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
         fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
+        fetchSafeJson(`${base}/data/allStar2025.json`, null),
       ]);
 
       console.log('로드된 데이터:', {
@@ -134,6 +136,7 @@ const useKboData = () => {
         teamChantsCount: teamChantsData?.length,
         kboPlayersCount: kboPlayersData?.length,
         teamRankCount: teamRankData?.results?.length,
+        allStarLoaded: !!allStar,
       });
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
@@ -419,12 +422,14 @@ const useKboData = () => {
         : [];
       setTeamRanks(ranks);
       setTeamRankTime(teamRankData?.crawl_time || null);
+      setAllStarData(allStar);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
         gameLineups: finalLineups.length,
         teamChants: parsedTeamChants.length,
         teamRanks: ranks.length,
+        allStar: allStar ? 'loaded' : 'none',
       });
 
     } catch (err) {
@@ -450,6 +455,7 @@ const useKboData = () => {
     fetchJsonData,
     teamRanks,
     teamRankTime,
+    allStarData,
   };
 };
 


### PR DESCRIPTION
## Summary
- integrate All-Star roster view directly in `LineupTab`
- drop the temporary `AllStarTab` component
- pass `allStarData` to `LineupTab`

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687378943278833189f4c4830e7aaa1d