### PR TITLE
Generate All-Star cheer song list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Run it after updating the Korean data:
 node scripts/generatePlayersEnglish.js
 ```
 
+## Generating All-Star song mapping
+
+`scripts/generateAllStarSongs.js` merges the All-Star roster with each player's
+cheer song information. The output is saved to
+`public/data/allStarSongs2025.json`.
+
+Run it whenever the All-Star or song data changes:
+
+```bash
+npm run build-allstar-songs
+```
+
 ## Crawling English player names
 
 `public/kbo_players_en_crawler.py` collects the official English names from

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "build-lineup-index": "node scripts/generateLineupIndex.js",
-    "update-song-mapping": "node scripts/updatePlayerSongTeams.js"
+    "update-song-mapping": "node scripts/updatePlayerSongTeams.js",
+    "build-allstar-songs": "node scripts/generateAllStarSongs.js"
   },
   "eslintConfig": {
     "extends": [

--- a/public/data/allStarSongs2025.json
+++ b/public/data/allStarSongs2025.json
@@ -1,0 +1,384 @@
+{
+  "dream": {
+    "best": [
+      {
+        "position": "투수",
+        "role": "선발",
+        "playerName": "박세웅",
+        "team": "롯데"
+      },
+      {
+        "position": "투수",
+        "role": "중간",
+        "playerName": "배찬승",
+        "team": "삼성"
+      },
+      {
+        "position": "투수",
+        "role": "마무리",
+        "playerName": "김원중",
+        "team": "롯데"
+      },
+      {
+        "position": "포수",
+        "playerName": "강민호",
+        "team": "삼성",
+        "chantTitle": "강민호 응원가",
+        "youtubeId": "PtmbsrHBcmg"
+      },
+      {
+        "position": "1루수",
+        "playerName": "디아즈",
+        "team": "삼성",
+        "chantTitle": "디아즈 응원가",
+        "youtubeId": "o9IbLhCeDOA"
+      },
+      {
+        "position": "2루수",
+        "playerName": "류지혁",
+        "team": "삼성",
+        "chantTitle": "류지혁 응원가",
+        "youtubeId": "dJnHFUKzGNM"
+      },
+      {
+        "position": "3루수",
+        "playerName": "최정",
+        "team": "SSG",
+        "chantTitle": "최정 응원가",
+        "youtubeId": "is-Ui9yfbP0"
+      },
+      {
+        "position": "유격수",
+        "playerName": "전민재",
+        "team": "롯데",
+        "chantTitle": "전민재 응원가",
+        "youtubeId": "jSSkeuGmwtQ"
+      },
+      {
+        "position": "외야수",
+        "playerName": "구자욱",
+        "team": "삼성",
+        "chantTitle": "구자욱 응원가",
+        "youtubeId": "3MxdMmF4eGM"
+      },
+      {
+        "position": "외야수",
+        "playerName": "김지찬",
+        "team": "삼성",
+        "chantTitle": "김지찬 응원가",
+        "youtubeId": "YJWJBJBfxw8"
+      },
+      {
+        "position": "외야수",
+        "playerName": "레이예스",
+        "team": "롯데",
+        "chantTitle": "레이예스 응원가",
+        "youtubeId": "o0SxKOMjDm0"
+      },
+      {
+        "position": "지명타자",
+        "playerName": "전준우",
+        "team": "롯데",
+        "chantTitle": "전준우 응원가",
+        "youtubeId": "mxAEq8hrNFk"
+      }
+    ],
+    "coachPicks": [
+      {
+        "position": "투수",
+        "playerName": "이호성",
+        "team": "삼성"
+      },
+      {
+        "position": "투수",
+        "playerName": "김택연",
+        "team": "두산"
+      },
+      {
+        "position": "투수",
+        "playerName": "박치국",
+        "team": "두산"
+      },
+      {
+        "position": "투수",
+        "playerName": "박영현",
+        "team": "KT"
+      },
+      {
+        "position": "투수",
+        "playerName": "우규민",
+        "team": "KT"
+      },
+      {
+        "position": "투수",
+        "playerName": "이로운",
+        "team": "SSG"
+      },
+      {
+        "position": "투수",
+        "playerName": "조병현",
+        "team": "SSG"
+      },
+      {
+        "position": "포수",
+        "playerName": "장성우",
+        "team": "KT",
+        "chantTitle": "장성우 응원가",
+        "youtubeId": "cBSqJueAdAg"
+      },
+      {
+        "position": "포수",
+        "playerName": "조형우",
+        "team": "SSG",
+        "chantTitle": "조형우 응원가",
+        "youtubeId": "Kz9pILMnqLI"
+      },
+      {
+        "position": "내야수",
+        "playerName": "오명진",
+        "team": "두산",
+        "chantTitle": "오명진 응원가",
+        "youtubeId": "hMT0MFqWkII"
+      },
+      {
+        "position": "내야수",
+        "playerName": "권동진",
+        "team": "KT",
+        "chantTitle": "권동진 응원가",
+        "youtubeId": "Uowr0Mb2tWE"
+      },
+      {
+        "position": "외야수",
+        "playerName": "배정대",
+        "team": "KT",
+        "chantTitle": "배정대 응원가",
+        "youtubeId": "E7MV9El05Fw"
+      },
+      {
+        "position": "외야수",
+        "playerName": "안현민",
+        "team": "KT",
+        "chantTitle": "안현민 응원가",
+        "youtubeId": "GC667SzI2yE"
+      }
+    ],
+    "coaches": [
+      {
+        "role": "감독",
+        "name": "박진만",
+        "team": "삼성"
+      },
+      {
+        "role": "코치",
+        "name": "조성환",
+        "team": "두산"
+      },
+      {
+        "role": "코치",
+        "name": "이강철",
+        "team": "KT"
+      },
+      {
+        "role": "코치",
+        "name": "이숭용",
+        "team": "SSG"
+      },
+      {
+        "role": "코치",
+        "name": "김태형",
+        "team": "롯데"
+      }
+    ]
+  },
+  "nanum": {
+    "best": [
+      {
+        "position": "투수",
+        "role": "선발",
+        "playerName": "폰세",
+        "team": "한화"
+      },
+      {
+        "position": "투수",
+        "role": "중간",
+        "playerName": "박상원",
+        "team": "한화"
+      },
+      {
+        "position": "투수",
+        "role": "마무리",
+        "playerName": "김서현",
+        "team": "한화"
+      },
+      {
+        "position": "포수",
+        "playerName": "박동원",
+        "team": "LG",
+        "chantTitle": "박동원 응원가",
+        "youtubeId": "A4wU4vFdS78"
+      },
+      {
+        "position": "1루수",
+        "playerName": "채은성",
+        "team": "한화",
+        "chantTitle": "채은성 응원가",
+        "youtubeId": "eOxOFlp-biY"
+      },
+      {
+        "position": "2루수",
+        "playerName": "박민우",
+        "team": "NC",
+        "chantTitle": "박민우 응원가",
+        "youtubeId": "JiMy5C6EAtg"
+      },
+      {
+        "position": "3루수",
+        "playerName": "송성문",
+        "team": "키움",
+        "chantTitle": "송성문 응원가",
+        "youtubeId": "jph7u2fAx14"
+      },
+      {
+        "position": "유격수",
+        "playerName": "박찬호",
+        "team": "KIA",
+        "chantTitle": "박찬호 응원가",
+        "youtubeId": "66tG87WSYtE"
+      },
+      {
+        "position": "외야수",
+        "playerName": "박건우",
+        "team": "NC",
+        "chantTitle": "박건우 응원가",
+        "youtubeId": "cDwR01RmHls"
+      },
+      {
+        "position": "외야수",
+        "playerName": "이주형",
+        "team": "키움",
+        "chantTitle": "이주형 응원가",
+        "youtubeId": "FEsH5-z5ILY"
+      },
+      {
+        "position": "외야수",
+        "playerName": "박해민",
+        "team": "LG",
+        "chantTitle": "박해민 응원가",
+        "youtubeId": "p2SvRcOthVc"
+      },
+      {
+        "position": "지명타자",
+        "playerName": "문현빈",
+        "team": "한화",
+        "chantTitle": "문현빈 응원가",
+        "youtubeId": "INx--Mz-rrU"
+      }
+    ],
+    "coachPicks": [
+      {
+        "position": "투수",
+        "playerName": "성영탁",
+        "team": "KIA"
+      },
+      {
+        "position": "투수",
+        "playerName": "최지민",
+        "team": "KIA"
+      },
+      {
+        "position": "투수",
+        "playerName": "김영우",
+        "team": "LG"
+      },
+      {
+        "position": "투수",
+        "playerName": "박명근",
+        "team": "LG"
+      },
+      {
+        "position": "투수",
+        "playerName": "배재환",
+        "team": "NC"
+      },
+      {
+        "position": "투수",
+        "playerName": "주승우",
+        "team": "키움"
+      },
+      {
+        "position": "투수",
+        "playerName": "하영민",
+        "team": "키움"
+      },
+      {
+        "position": "포수",
+        "playerName": "김태군",
+        "team": "KIA",
+        "chantTitle": "김태군 응원가",
+        "youtubeId": "DHtPCRFlNdA"
+      },
+      {
+        "position": "포수",
+        "playerName": "김형준",
+        "team": "NC",
+        "chantTitle": "김형준 응원가",
+        "youtubeId": "8QM6lnJb1BI"
+      },
+      {
+        "position": "내야수",
+        "playerName": "이도윤",
+        "team": "한화",
+        "chantTitle": "이도윤 응원가",
+        "youtubeId": "bAPCz-Peu4g"
+      },
+      {
+        "position": "내야수",
+        "playerName": "김주원",
+        "team": "NC",
+        "chantTitle": "김주원 응원가",
+        "youtubeId": "qi__U-aVeGw"
+      },
+      {
+        "position": "외야수",
+        "playerName": "김현수",
+        "team": "LG",
+        "chantTitle": "김현수 응원가",
+        "youtubeId": "SrXNLHJmcfM"
+      },
+      {
+        "position": "외야수",
+        "playerName": "김호령",
+        "team": "KIA",
+        "chantTitle": "김호령 응원가",
+        "youtubeId": "Jh3sUlrc9kE"
+      }
+    ],
+    "coaches": [
+      {
+        "role": "감독",
+        "name": "이범호",
+        "team": "KIA"
+      },
+      {
+        "role": "코치",
+        "name": "염경엽",
+        "team": "LG"
+      },
+      {
+        "role": "코치",
+        "name": "김경문",
+        "team": "한화"
+      },
+      {
+        "role": "코치",
+        "name": "이호준",
+        "team": "NC"
+      },
+      {
+        "role": "코치",
+        "name": "홍원기",
+        "team": "키움"
+      }
+    ]
+  }
+}

--- a/scripts/generateAllStarSongs.js
+++ b/scripts/generateAllStarSongs.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const allStarPath = path.join(__dirname, '..', 'public', 'data', 'allStar2025.json');
+const songsPath = path.join(__dirname, '..', 'public', 'data', 'playerSongs.json');
+const outPath = path.join(__dirname, '..', 'public', 'data', 'allStarSongs2025.json');
+
+function loadJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function findSong(songs, playerName, team) {
+  return songs.find((s) => s.playerName === playerName && s.team === team);
+}
+
+function addSongs(roster, songs) {
+  ['best', 'coachPicks'].forEach((section) => {
+    if (!Array.isArray(roster[section])) return;
+    roster[section] = roster[section].map((entry) => {
+      if (!entry.playerName) return entry;
+      const song = findSong(songs, entry.playerName, entry.team);
+      if (song) {
+        return { ...entry, chantTitle: song.chantTitle, youtubeId: song.youtubeId };
+      }
+      return entry;
+    });
+  });
+}
+
+function generate() {
+  const allStar = loadJson(allStarPath);
+  const songs = loadJson(songsPath);
+
+  const output = JSON.parse(JSON.stringify(allStar));
+  addSongs(output.dream, songs);
+  addSongs(output.nanum, songs);
+
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+  console.log(`Wrote song mapping to ${outPath}`);
+}
+
+if (require.main === module) {
+  generate();
+}
+
+module.exports = generate;


### PR DESCRIPTION
## Summary
- add script to merge All-Star roster with cheer songs
- document the new script in README
- generate `allStarSongs2025.json` using the script

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build-allstar-songs`

------
https://chatgpt.com/codex/tasks/task_e_6874ac7afd108331baa74218f8ae28d3