### PR TITLE
Add stadium road weather integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,5 +155,14 @@ On first visit the site asks you to choose your favorite team. The choice is sav
 in `localStorage` under `favoriteTeam` so it persists across sessions. If you want
 to pick again, clear your browser storage or remove that key.
 
+## Stadium road weather
+
+The app can display near-stadium road weather using the Korea Meteorological
+Administration's Road Weather API. The mapping of each KBO stadium to its CCTV
+IDs lives in `public/data/stadiumCctvIds.json`.
+
+Set the API key in your environment as `REACT_APP_ROAD_API_KEY` and the lineup
+tab will show a small section with live conditions.
+
 © 2025 직관가자. All rights reserved.
 Created and maintained by Sumin Lee.

--- a/public/data/stadiumCctvIds.json
+++ b/public/data/stadiumCctvIds.json
@@ -1,0 +1,47 @@
+[
+  {
+    "team": "LG Twins / Doosan Bears",
+    "stadiumName": "잠실야구장",
+    "eqmtIds": ["2070C00006", "2088C00005"]
+  },
+  {
+    "team": "Kiwoom Heroes",
+    "stadiumName": "고척 스카이돔",
+    "eqmtIds": ["1001C00004", "1001C00005"]
+  },
+  {
+    "team": "SSG Landers",
+    "stadiumName": "인천 SSG 랜더스필드",
+    "eqmtIds": ["2240019101", "1650004200"]
+  },
+  {
+    "team": "KT Wiz",
+    "stadiumName": "수원 KT 위즈파크",
+    "eqmtIds": ["2080001300", "2080002001"]
+  },
+  {
+    "team": "Hanwha Eagles",
+    "stadiumName": "대전 한화생명 이글스파크",
+    "eqmtIds": ["2023T44", "2023T43"]
+  },
+  {
+    "team": "KIA Tigers",
+    "stadiumName": "광주 KIA 챔피언스필드",
+    "eqmtIds": ["0250C00060", "0250C00059"]
+  },
+  {
+    "team": "Samsung Lions",
+    "stadiumName": "대구 삼성 라이온즈 파크",
+    "eqmtIds": ["0550C00106", "0550C00107"]
+  },
+  {
+    "team": "NC Dinos",
+    "stadiumName": "창원 NC파크",
+    "eqmtIds": ["0450C00100", "0450C00101"]
+  },
+  {
+    "team": "Lotte Giants",
+    "stadiumName": "부산 사직야구장",
+    "eqmtIds": ["2023T113", "2023T114"]
+  }
+]

--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,7 @@ import CalendarDropdown from './components/CalendarDropdown';
 import TeamDropdown from './components/TeamDropdown';
 import useKboData from './hooks/useKboData';
 import Footer from './components/Footer';
+import { mapEqmtIds } from './utils/weather';
 // import AddToHomePopup from './components/AddToHomePopup';
 import TeamSelectModal from './components/TeamSelectModal';
 
@@ -220,6 +221,7 @@ const JikgwanGaja = () => {
     teamRanks,
     teamRankTime,
     allStarData,
+    stadiumCctvIds,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -235,6 +237,9 @@ const JikgwanGaja = () => {
       ),
     [gameLineups, selectedTeam]
   );
+
+  const eqmtMap = useMemo(() => mapEqmtIds(stadiumCctvIds), [stadiumCctvIds]);
+  const selectedEqmtIds = eqmtMap[selectedTeam] || [];
 
   useEffect(() => {
     if (pendingPlayerName && playerSongs.length > 0) {
@@ -964,6 +969,7 @@ const getSortedChants = () => {
                 teamRanks={teamRanks}
                 getDisplayName={getDisplayName}
                 allStarData={allStarData}
+                eqmtIds={selectedEqmtIds}
               />
             )}
             {activeTab === 'teamChants' && (

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,6 +6,8 @@ const Footer = () => (
     <br />
     Created and maintained by Sumin Lee.
     <br />
+    Road weather data © Korea Meteorological Administration.
+    <br />
     <a
       href="mailto:jikgwangaza@gmail.com?subject=Bug%20Report"
       className="underline hover:text-blue-600"

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -3,6 +3,7 @@ import PlayerCard from './PlayerCard';
 import StartingPitcherCard from './StartingPitcherCard';
 import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
 import { getTeamInfo } from '../utils/team';
+import StadiumWeather from './StadiumWeather';
 
 const LineupTab = ({
   currentLineup,
@@ -29,6 +30,7 @@ const LineupTab = ({
   teamRanks,
   getDisplayName,
   allStarData,
+  eqmtIds,
 }) => {
   const currentGame = getCurrentGame();
   const [allStarTeam, setAllStarTeam] = useState('dream');
@@ -125,6 +127,10 @@ const LineupTab = ({
           </button>
         </div>
       </div>
+
+      {eqmtIds && eqmtIds.length > 0 && (
+        <StadiumWeather eqmtIds={eqmtIds} />
+      )}
 
       {availableGames && availableGames.length > 1 && (
         <div className="mb-2">

--- a/src/components/StadiumWeather.jsx
+++ b/src/components/StadiumWeather.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+
+const fetchWeather = async (eqmtId) => {
+  const baseUrl = 'http://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr';
+  const params = new URLSearchParams({
+    serviceKey: process.env.REACT_APP_ROAD_API_KEY || '',
+    pageNo: '1',
+    numOfRows: '1',
+    dataType: 'JSON',
+    eqmtId,
+    hhCode: '00',
+  });
+
+  try {
+    const res = await fetch(`${baseUrl}?${params.toString()}`);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const item = data?.response?.body?.items?.item?.[0];
+    return item?.weatherNm || '정보없음';
+  } catch (err) {
+    console.warn('날씨 조회 실패', err);
+    return '정보없음';
+  }
+};
+
+const StadiumWeather = ({ eqmtIds = [] }) => {
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    const run = async () => {
+      const outs = [];
+      for (const id of eqmtIds) {
+        outs.push({ id, weather: await fetchWeather(id) });
+      }
+      setResults(outs);
+    };
+    if (eqmtIds.length > 0) {
+      run();
+    }
+  }, [eqmtIds]);
+
+  if (!eqmtIds.length) return null;
+
+  return (
+    <div className="text-sm mb-3" data-testid="stadium-weather">
+      <h3 className="font-semibold mb-1">구장 주변 도로 날씨</h3>
+      <ul className="list-disc list-inside space-y-1">
+        {results.map((r) => (
+          <li key={r.id}>
+            {r.id}: {r.weather}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StadiumWeather;

--- a/src/components/StadiumWeather.test.js
+++ b/src/components/StadiumWeather.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import StadiumWeather from './StadiumWeather';
+
+jest.mock('./StadiumWeather', () => jest.requireActual('./StadiumWeather'));
+
+// Mock fetch
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          response: { body: { items: { item: [{ weatherNm: '맑음' }] } } },
+        }),
+    })
+  );
+});
+
+afterEach(() => {
+  fetch.mockClear();
+});
+
+test('renders weather list', async () => {
+  render(<StadiumWeather eqmtIds={["123", "456"]} />);
+  expect(screen.getByTestId('stadium-weather')).toBeInTheDocument();
+  // Wait for fetch
+  const items = await screen.findAllByRole('listitem');
+  expect(items.length).toBe(2);
+});

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -100,6 +100,7 @@ const useKboData = () => {
   const [teamRanks, setTeamRanks] = useState([]);
   const [teamRankTime, setTeamRankTime] = useState(null);
   const [allStarData, setAllStarData] = useState(null);
+  const [stadiumCctvIds, setStadiumCctvIds] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -120,7 +121,7 @@ const useKboData = () => {
     try {
       const base = process.env.PUBLIC_URL || '';
 
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, allStar] = await Promise.all([
+      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, allStar, stadiumCctvData] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
         fetchSafeJson(`${base}/data/kbo_crawler_data/index.json`, null),
         fetchSafeJson(`${base}/data/teamChants.json`, []),
@@ -128,6 +129,7 @@ const useKboData = () => {
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
         fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
         fetchSafeJson(`${base}/data/allStar2025.json`, null),
+        fetchSafeJson(`${base}/data/stadiumCctvIds.json`, []),
       ]);
 
       console.log('로드된 데이터:', {
@@ -137,6 +139,7 @@ const useKboData = () => {
         kboPlayersCount: kboPlayersData?.length,
         teamRankCount: teamRankData?.results?.length,
         allStarLoaded: !!allStar,
+        stadiumCctvCount: stadiumCctvData?.length,
       });
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
@@ -423,6 +426,7 @@ const useKboData = () => {
       setTeamRanks(ranks);
       setTeamRankTime(teamRankData?.crawl_time || null);
       setAllStarData(allStar);
+      setStadiumCctvIds(Array.isArray(stadiumCctvData) ? stadiumCctvData : []);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
@@ -430,6 +434,7 @@ const useKboData = () => {
         teamChants: parsedTeamChants.length,
         teamRanks: ranks.length,
         allStar: allStar ? 'loaded' : 'none',
+        stadiumCctv: Array.isArray(stadiumCctvData) ? stadiumCctvData.length : 0,
       });
 
     } catch (err) {
@@ -456,6 +461,7 @@ const useKboData = () => {
     teamRanks,
     teamRankTime,
     allStarData,
+    stadiumCctvIds,
   };
 };
 

--- a/src/utils/weather.js
+++ b/src/utils/weather.js
@@ -1,0 +1,10 @@
+export const mapEqmtIds = (data) => {
+  const map = {};
+  data.forEach((item) => {
+    const teams = item.team.split('/').map((t) => t.trim());
+    teams.forEach((t) => {
+      map[t] = item.eqmtIds;
+    });
+  });
+  return map;
+};


### PR DESCRIPTION
## Summary
- connect to KMA road weather API
- fetch stadium CCTV ID mappings
- show weather on lineup tab using new `StadiumWeather` component
- document API usage in README
- credit KMA in footer
- add unit test for the component

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a336b73748331a05ebb8fe664231d