### PR TITLE
Fix weather API mixed content

### DIFF
--- a/src/components/StadiumWeather.jsx
+++ b/src/components/StadiumWeather.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 const fetchWeather = async (eqmtId) => {
-  const baseUrl = 'http://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr';
+  const baseUrl = 'https://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr';
   const params = new URLSearchParams({
     serviceKey: process.env.REACT_APP_ROAD_API_KEY || '',
     pageNo: '1',


### PR DESCRIPTION
## Summary
- use `https` when fetching stadium weather

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4325ad10833193e522a389aa8c00