### PR TITLE
Add automatic ballpark weather collector

### DIFF
--- a/.github/workflows/weather-update.yml
+++ b/.github/workflows/weather-update.yml
@@ -1,0 +1,41 @@
+name: Update ballpark weather
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+    - cron: '*/15 8-13 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-weather:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Run update_weather.py
+        env:
+          GOKR_WEATHER_API_KEY: ${{ secrets.GOKR_WEATHER_API_KEY }}
+        run: python update_weather.py
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/kboBallparkWeather.json
+          git commit -m 'Update ballpark weather' || echo 'No changes to commit'
+          git pull --rebase origin main
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -157,12 +157,11 @@ to pick again, clear your browser storage or remove that key.
 
 ## Stadium road weather
 
-The app can display near-stadium road weather using the Korea Meteorological
-Administration's Road Weather API. The mapping of each KBO stadium to its CCTV
-IDs lives in `public/data/stadiumCctvIds.json`.
-
-Set the API key in your environment as `REACT_APP_ROAD_API_KEY` and the lineup
-tab will show a small section with live conditions.
+The app shows near-stadium road weather from the Korea Meteorological
+Administration. A GitHub Actions workflow runs `update_weather.py` regularly and
+writes the latest results to `public/data/kboBallparkWeather.json`. The mapping
+of each ballpark to its CCTV ID lives in `public/data/ballpark_weather_sources.json`.
+The workflow uses the secret `GOKR_WEATHER_API_KEY` when calling the API.
 
 © 2025 직관가자. All rights reserved.
 Created and maintained by Sumin Lee.

--- a/public/data/ballpark_weather_sources.json
+++ b/public/data/ballpark_weather_sources.json
@@ -1,0 +1,47 @@
+[
+  {
+    "team": "LG Twins / Doosan Bears",
+    "stadium": "잠실야구장",
+    "eqmtId": "2070C00006"
+  },
+  {
+    "team": "Kiwoom Heroes",
+    "stadium": "고척 스카이돔",
+    "eqmtId": "1001C00004"
+  },
+  {
+    "team": "SSG Landers",
+    "stadium": "인천 SSG 랜더스필드",
+    "eqmtId": "2240019101"
+  },
+  {
+    "team": "KT Wiz",
+    "stadium": "수원 KT 위즈파크",
+    "eqmtId": "2080001300"
+  },
+  {
+    "team": "Hanwha Eagles",
+    "stadium": "대전 한화생명 이글스파크",
+    "eqmtId": "2023T44"
+  },
+  {
+    "team": "KIA Tigers",
+    "stadium": "광주 KIA 챔피언스필드",
+    "eqmtId": "0250C00060"
+  },
+  {
+    "team": "Samsung Lions",
+    "stadium": "대구 삼성 라이온즈 파크",
+    "eqmtId": "0550C00106"
+  },
+  {
+    "team": "NC Dinos",
+    "stadium": "창원 NC파크",
+    "eqmtId": "0450C00100"
+  },
+  {
+    "team": "Lotte Giants",
+    "stadium": "부산 사직야구장",
+    "eqmtId": "2023T113"
+  }
+]

--- a/public/data/kboBallparkWeather.json
+++ b/public/data/kboBallparkWeather.json
@@ -1,0 +1,4 @@
+{
+  "updatedAt": "",
+  "data": []
+}

--- a/src/components/StadiumWeather.jsx
+++ b/src/components/StadiumWeather.jsx
@@ -1,53 +1,43 @@
 import React, { useEffect, useState } from 'react';
 
-const fetchWeather = async (eqmtId) => {
-  const baseUrl = 'https://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr';
-  const params = new URLSearchParams({
-    serviceKey: process.env.REACT_APP_ROAD_API_KEY || '',
-    pageNo: '1',
-    numOfRows: '1',
-    dataType: 'JSON',
-    eqmtId,
-    hhCode: '00',
-  });
-
-  try {
-    const res = await fetch(`${baseUrl}?${params.toString()}`);
-    if (!res.ok) throw new Error('HTTP ' + res.status);
-    const data = await res.json();
-    const item = data?.response?.body?.items?.item?.[0];
-    return item?.weatherNm || '정보없음';
-  } catch (err) {
-    console.warn('날씨 조회 실패', err);
-    return '정보없음';
-  }
-};
-
 const StadiumWeather = ({ eqmtIds = [] }) => {
-  const [results, setResults] = useState([]);
+  const [data, setData] = useState(null);
 
   useEffect(() => {
-    const run = async () => {
-      const outs = [];
-      for (const id of eqmtIds) {
-        outs.push({ id, weather: await fetchWeather(id) });
+    const load = async () => {
+      try {
+        const base = process.env.PUBLIC_URL || '';
+        const res = await fetch(`${base}/data/kboBallparkWeather.json`);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        console.warn('날씨 데이터 로드 실패', err);
       }
-      setResults(outs);
     };
-    if (eqmtIds.length > 0) {
-      run();
-    }
-  }, [eqmtIds]);
+    load();
+  }, []);
 
-  if (!eqmtIds.length) return null;
+  if (!eqmtIds.length || !data) return null;
+
+  const items = data.data.filter((d) => eqmtIds.includes(d.eqmtId));
+  if (items.length === 0) return null;
+
+  const timeLabel = data.updatedAt
+    ? `기준 시각: ${new Date(data.updatedAt).toLocaleTimeString('ko-KR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      })}`
+    : null;
 
   return (
     <div className="text-sm mb-3" data-testid="stadium-weather">
       <h3 className="font-semibold mb-1">구장 주변 도로 날씨</h3>
+      {timeLabel && <p className="text-gray-500 mb-1">{timeLabel}</p>}
       <ul className="list-disc list-inside space-y-1">
-        {results.map((r) => (
-          <li key={r.id}>
-            {r.id}: {r.weather}
+        {items.map((r) => (
+          <li key={r.eqmtId}>
+            {r.stadium}: {r.weatherNm}
           </li>
         ))}
       </ul>

--- a/src/components/StadiumWeather.test.js
+++ b/src/components/StadiumWeather.test.js
@@ -10,7 +10,11 @@ beforeEach(() => {
       ok: true,
       json: () =>
         Promise.resolve({
-          response: { body: { items: { item: [{ weatherNm: '맑음' }] } } },
+          updatedAt: '2025-07-18T17:00:00+09:00',
+          data: [
+            { eqmtId: '123', stadium: 'A', weatherNm: '맑음', team: 'T1' },
+            { eqmtId: '456', stadium: 'B', weatherNm: '흐림', team: 'T2' },
+          ],
         }),
     })
   );

--- a/update_weather.py
+++ b/update_weather.py
@@ -1,0 +1,54 @@
+import json
+import os
+from datetime import datetime, timezone, timedelta
+import requests
+
+BASE_URL = "https://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr"
+SERVICE_KEY = os.environ.get("GOKR_WEATHER_API_KEY")
+
+if not SERVICE_KEY:
+    raise SystemExit("GOKR_WEATHER_API_KEY environment variable not set")
+
+with open("public/data/ballpark_weather_sources.json", "r", encoding="utf-8") as f:
+    sources = json.load(f)
+
+results = []
+for item in sources:
+    params = {
+        "serviceKey": SERVICE_KEY,
+        "pageNo": "1",
+        "numOfRows": "1",
+        "dataType": "JSON",
+        "eqmtId": item["eqmtId"],
+        "hhCode": "00",
+    }
+    try:
+        resp = requests.get(BASE_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        weather = (
+            data.get("response", {})
+            .get("body", {})
+            .get("items", {})
+            .get("item", [{}])[0]
+            .get("weatherNm", "정보없음")
+        )
+    except Exception as e:
+        print("Failed to fetch", item["eqmtId"], e)
+        weather = "정보없음"
+    results.append({
+        "team": item["team"],
+        "stadium": item["stadium"],
+        "weatherNm": weather,
+        "eqmtId": item["eqmtId"],
+    })
+
+kst = timezone(timedelta(hours=9))
+output = {
+    "updatedAt": datetime.now(kst).isoformat(),
+    "data": results,
+}
+
+with open("public/data/kboBallparkWeather.json", "w", encoding="utf-8") as f:
+    json.dump(output, f, ensure_ascii=False, indent=2)
+    f.write("\n")


### PR DESCRIPTION
## Summary
- fetch near-stadium weather in `update_weather.py`
- store static weather sources and latest results under `public/data`
- show weather using the static JSON instead of API calls
- create workflow to update weather data
- document the new process

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a549ac67483318ec7e67e0f2a4172