### PR TITLE
Improve ballpark weather display

### DIFF
--- a/src/components/StadiumWeather.jsx
+++ b/src/components/StadiumWeather.jsx
@@ -23,21 +23,35 @@ const StadiumWeather = ({ eqmtIds = [] }) => {
   const items = data.data.filter((d) => eqmtIds.includes(d.eqmtId));
   if (items.length === 0) return null;
 
-  const timeLabel = data.updatedAt
-    ? `기준 시각: ${new Date(data.updatedAt).toLocaleTimeString('ko-KR', {
+  const timeStr = data.updatedAt
+    ? new Date(data.updatedAt).toLocaleTimeString('ko-KR', {
         hour: '2-digit',
         minute: '2-digit',
-      })}`
+        hourCycle: 'h23',
+      })
     : null;
+
+  const iconMap = {
+    맑음: '☀️',
+    '구름많음': '⛅',
+    '구름 많음': '⛅',
+    흐림: '☁️',
+    비: '🌧️',
+    눈: '❄️',
+    '눈/비': '🌨️',
+    정보없음: '❓',
+  };
+
+  const getIcon = (name) => iconMap[name] || '🌡️';
 
   return (
     <div className="text-sm mb-3" data-testid="stadium-weather">
       <h3 className="font-semibold mb-1">구장 주변 도로 날씨</h3>
-      {timeLabel && <p className="text-gray-500 mb-1">{timeLabel}</p>}
       <ul className="list-disc list-inside space-y-1">
         {items.map((r) => (
           <li key={r.eqmtId}>
-            {r.stadium}: {r.weatherNm}
+            ⚾ {r.stadium} {getIcon(r.weatherNm)} {r.weatherNm}
+            {timeStr ? ` (기준 시각: ${timeStr})` : ''}
           </li>
         ))}
       </ul>

--- a/src/components/StadiumWeather.test.js
+++ b/src/components/StadiumWeather.test.js
@@ -30,4 +30,7 @@ test('renders weather list', async () => {
   // Wait for fetch
   const items = await screen.findAllByRole('listitem');
   expect(items.length).toBe(2);
+  expect(items[0].textContent).toContain('⚾ A');
+  expect(items[0].textContent).toContain('맑음');
+  expect(items[0].textContent).toContain('17:00');
 });

--- a/src/utils/team.js
+++ b/src/utils/team.js
@@ -6,7 +6,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_HT.png',
       fullName: 'KIA 타이거즈',
       fullNameEn: 'KIA Tigers',
-      stadium: '광주'
+      stadium: '광주 KIA 챔피언스필드'
     },
     HT: {
       color: '#EA0029',
@@ -14,7 +14,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_HT.png',
       fullName: 'KIA 타이거즈',
       fullNameEn: 'KIA Tigers',
-      stadium: '광주'
+      stadium: '광주 KIA 챔피언스필드'
     },
     두산: {
       color: '#131230',
@@ -22,7 +22,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_OB.png',
       fullName: '두산 베어스',
       fullNameEn: 'Doosan Bears',
-      stadium: '잠실'
+      stadium: '잠실야구장'
     },
     OB: {
       color: '#131230',
@@ -30,7 +30,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_OB.png',
       fullName: '두산 베어스',
       fullNameEn: 'Doosan Bears',
-      stadium: '잠실'
+      stadium: '잠실야구장'
     },
     LG: {
       color: '#C30452',
@@ -38,7 +38,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_LG.png',
       fullName: 'LG 트윈스',
       fullNameEn: 'LG Twins',
-      stadium: '잠실'
+      stadium: '잠실야구장'
     },
     삼성: {
       color: '#074CA1',
@@ -46,7 +46,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_SS.png',
       fullName: '삼성 라이온즈',
       fullNameEn: 'Samsung Lions',
-      stadium: '대구'
+      stadium: '대구 삼성 라이온즈 파크'
     },
     SS: {
       color: '#074CA1',
@@ -54,7 +54,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_SS.png',
       fullName: '삼성 라이온즈',
       fullNameEn: 'Samsung Lions',
-      stadium: '대구'
+      stadium: '대구 삼성 라이온즈 파크'
     },
     롯데: {
       color: '#041E42',
@@ -62,7 +62,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_LT.png',
       fullName: '롯데 자이언츠',
       fullNameEn: 'Lotte Giants',
-      stadium: '사직'
+      stadium: '부산 사직야구장'
     },
     LT: {
       color: '#041E42',
@@ -70,7 +70,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_LT.png',
       fullName: '롯데 자이언츠',
       fullNameEn: 'Lotte Giants',
-      stadium: '사직'
+      stadium: '부산 사직야구장'
     },
     SSG: {
       color: '#CE0E2D',
@@ -78,7 +78,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_SK.png',
       fullName: 'SSG 랜더스',
       fullNameEn: 'SSG Landers',
-      stadium: '문학'
+      stadium: '인천 SSG 랜더스필드'
     },
     SK: {
       color: '#CE0E2D',
@@ -86,7 +86,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_SK.png',
       fullName: 'SSG 랜더스',
       fullNameEn: 'SSG Landers',
-      stadium: '문학'
+      stadium: '인천 SSG 랜더스필드'
     },
     키움: {
       color: '#570514',
@@ -94,7 +94,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_WO.png',
       fullName: '키움 히어로즈',
       fullNameEn: 'Kiwoom Heroes',
-      stadium: '고척'
+      stadium: '고척 스카이돔'
     },
     WO: {
       color: '#570514',
@@ -102,7 +102,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_WO.png',
       fullName: '키움 히어로즈',
       fullNameEn: 'Kiwoom Heroes',
-      stadium: '고척'
+      stadium: '고척 스카이돔'
     },
     한화: {
       color: '#FF6600',
@@ -110,7 +110,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_HH.png',
       fullName: '한화 이글스',
       fullNameEn: 'Hanwha Eagles',
-      stadium: '대전'
+      stadium: '대전 한화생명 이글스파크'
     },
     HH: {
       color: '#FF6600',
@@ -118,7 +118,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_HH.png',
       fullName: '한화 이글스',
       fullNameEn: 'Hanwha Eagles',
-      stadium: '대전'
+      stadium: '대전 한화생명 이글스파크'
     },
     NC: {
       color: '#315288',
@@ -126,7 +126,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_NC.png',
       fullName: 'NC 다이노스',
       fullNameEn: 'NC Dinos',
-      stadium: '창원'
+      stadium: '창원 NC파크'
     },
     KT: {
       color: '#000000',
@@ -134,7 +134,7 @@ export const getTeamInfo = team => {
       logo: 'https://6ptotvmi5753.edge.naverncp.com/KBO_IMAGE/emblem/regular/fixed/emblem_KT.png',
       fullName: 'KT 위즈',
       fullNameEn: 'KT Wiz',
-      stadium: '수원'
+      stadium: '수원 KT 위즈파크'
     }
   };
   return (


### PR DESCRIPTION
## Summary
- show weather icons and 24h timestamps in `StadiumWeather`
- add full ballpark names to team info
- update tests for the new weather output

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5eb161b88331bd86b133670f48cd