### PR TITLE
Update schedule display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1020,6 +1020,7 @@ const getSortedChants = () => {
                 formatDateKorean={formatDateKorean}
                 setSelectedDate={setSelectedDate}
                 setActiveTab={setActiveTab}
+                teamRanks={teamRanks}
               />
             )}
           </>
@@ -1045,6 +1046,7 @@ const getSortedChants = () => {
               formatDateKorean={formatDateKorean}
               setSelectedDate={setSelectedDate}
               setActiveTab={setActiveTab}
+              teamRanks={teamRanks}
             />
           </div>
         </div>

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -4,6 +4,7 @@ import StartingPitcherCard from './StartingPitcherCard';
 import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
 import { getTeamInfo } from '../utils/team';
 import StadiumWeather from './StadiumWeather';
+import useBallparkWeather from '../hooks/useBallparkWeather';
 
 const LineupTab = ({
   currentLineup,
@@ -33,6 +34,7 @@ const LineupTab = ({
   eqmtIds,
 }) => {
   const currentGame = getCurrentGame();
+  const weatherMap = useBallparkWeather();
   const [allStarTeam, setAllStarTeam] = useState('dream');
   const isAllStarDay = selectedDate === '2025-07-12';
   const getRank = (team) => {
@@ -198,27 +200,33 @@ const LineupTab = ({
                   )}
                   <span className="text-xs text-gray-500">(홈)</span>
                 </div>
-                <p className="text-sm text-gray-600 dark:text-gray-300">
-                  {currentGame.location ||
-                    getTeamInfo(currentGame.home).stadium}{' '}
-                  • {formatDateKorean(currentGame.date)}
-                  {(() => {
-                    const isCanceled =
-                      currentGame.canceled ||
-                      (currentGame.gameStatus && currentGame.gameStatus.includes('취소'));
-                    const gameDate = new Date(currentGame.date);
-                    const nextDay = new Date(gameDate);
-                    nextDay.setDate(gameDate.getDate() + 1);
-                    nextDay.setHours(0, 0, 0, 0);
-                    const isPast = new Date() >= nextDay;
+                <div className="text-sm text-gray-600 dark:text-gray-300 leading-snug">
+                  <div>
+                    {currentGame.location || getTeamInfo(currentGame.home).stadium}
+                    {weatherMap[currentGame.location || getTeamInfo(currentGame.home).stadium]
+                      ? ` • ${weatherMap[currentGame.location || getTeamInfo(currentGame.home).stadium]}`
+                      : ''}
+                  </div>
+                  <div>
+                    {formatDateKorean(currentGame.date)}
+                    {(() => {
+                      const isCanceled =
+                        currentGame.canceled ||
+                        (currentGame.gameStatus && currentGame.gameStatus.includes('취소'));
+                      const gameDate = new Date(currentGame.date);
+                      const nextDay = new Date(gameDate);
+                      nextDay.setDate(gameDate.getDate() + 1);
+                      nextDay.setHours(0, 0, 0, 0);
+                      const isPast = new Date() >= nextDay;
 
-                    let status = currentGame.gameStatus || '';
-                    if (!isCanceled && isPast) {
-                      status = '종료';
-                    }
-                    return status ? ` • ${status}` : '';
-                  })()}
-                </p>
+                      let status = currentGame.gameStatus || '';
+                      if (!isCanceled && isPast) {
+                        status = '종료';
+                      }
+                      return status ? ` • ${status}` : '';
+                    })()}
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Calendar } from 'lucide-react';
 import { getTeamInfo } from '../utils/team';
+import useBallparkWeather from '../hooks/useBallparkWeather';
 
 const ALL_TEAMS = [
   'KIA',
@@ -21,8 +22,15 @@ const ScheduleTab = ({
   formatDateKorean,
   setSelectedDate,
   setActiveTab,
+  teamRanks,
 }) => {
   const [locationFilter, setLocationFilter] = useState('전체');
+  const weatherMap = useBallparkWeather();
+
+  const getRank = (team) => {
+    const r = teamRanks?.find((t) => t.team === team);
+    return r ? `${r.rank}위` : '';
+  };
 
   const schedules = gameLineups
     .filter((game) => game.team === selectedTeam)
@@ -71,13 +79,16 @@ const ScheduleTab = ({
           return (
             <div
               key={game.id}
-              onClick={() => { if (setSelectedDate) setSelectedDate(game.date); if (setActiveTab) setActiveTab("lineup"); }}
+              onClick={() => {
+                if (setSelectedDate) setSelectedDate(game.date);
+                if (setActiveTab) setActiveTab('lineup');
+              }}
               className={`cursor-pointer flex items-center justify-between rounded-lg p-3 shadow ${
                 isCanceled
-                ? 'bg-gray-100 dark:bg-gray-800 text-gray-500 line-through'
-                : 'bg-white dark:bg-gray-700'
-            }`}
-          >
+                  ? 'bg-gray-100 dark:bg-gray-800 text-gray-500 line-through'
+                  : 'bg-white dark:bg-gray-700'
+              }`}
+            >
             <div className="flex items-center gap-2">
               {getTeamInfo(game.away).logo && (
                 <img
@@ -87,6 +98,11 @@ const ScheduleTab = ({
                 />
               )}
               <span className="font-medium">{game.away}</span>
+              {getRank(game.away) && (
+                <span className="text-xs text-gray-700 dark:text-gray-300 ml-1">
+                  {getRank(game.away)}
+                </span>
+              )}
               <span className="text-xs text-gray-500 dark:text-gray-400">(원정)</span>
               <span className="mx-1 text-gray-500 dark:text-gray-400">vs</span>
               {getTeamInfo(game.home).logo && (
@@ -97,21 +113,28 @@ const ScheduleTab = ({
                 />
               )}
               <span className="font-medium">{game.home}</span>
+              {getRank(game.home) && (
+                <span className="text-xs text-gray-700 dark:text-gray-300 ml-1">
+                  {getRank(game.home)}
+                </span>
+              )}
               <span className="text-xs text-gray-500 dark:text-gray-400">(홈)</span>
             </div>
-            <div className="text-sm text-right text-gray-600 dark:text-gray-300">
-                <div>
-                  {game.gameTime || '미정'} •{' '}
-                  {game.location || getTeamInfo(game.home).stadium}
-                </div>
-                <div>
-                  {formatDateKorean(game.date)}
-                  {displayStatus ? ` • ${displayStatus}` : ''}
-                </div>
+            <div className="text-sm text-right text-gray-600 dark:text-gray-300 leading-snug">
+              <div>
+                {game.location || getTeamInfo(game.home).stadium}
+                {weatherMap[game.location || getTeamInfo(game.home).stadium]
+                  ? ` • ${weatherMap[game.location || getTeamInfo(game.home).stadium]}`
+                  : ''}
+              </div>
+              <div>
+                {formatDateKorean(game.date)}
+                {displayStatus ? ` • ${displayStatus}` : ''}
               </div>
             </div>
-          );
-        })}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/hooks/useBallparkWeather.js
+++ b/src/hooks/useBallparkWeather.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+const useBallparkWeather = () => {
+  const [map, setMap] = useState({});
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const base = process.env.PUBLIC_URL || '';
+        const res = await fetch(`${base}/data/kboBallparkWeather.json`);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const json = await res.json();
+        const m = {};
+        if (Array.isArray(json.data)) {
+          json.data.forEach((d) => {
+            m[d.stadium] = d.weatherNm;
+          });
+        }
+        setMap(m);
+      } catch (err) {
+        console.warn('날씨 데이터 로드 실패', err);
+      }
+    };
+    load();
+  }, []);
+
+  return map;
+};
+
+export default useBallparkWeather;


### PR DESCRIPTION
## Summary
- display ballpark weather in header via new `useBallparkWeather` hook
- show team ranks in schedule list
- pass team rank data into `ScheduleTab`
- split lineup header info onto three lines

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a64889a0c83319231d680aa1e1e9d