### PR TITLE
Improve weather updater with CCTV fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,11 @@ to pick again, clear your browser storage or remove that key.
 The app shows near-stadium road weather from the Korea Meteorological
 Administration. A GitHub Actions workflow runs `update_weather.py` regularly and
 writes the latest results to `public/data/kboBallparkWeather.json`. The mapping
-of each ballpark to its CCTV ID lives in `public/data/ballpark_weather_sources.json`.
-The workflow uses the secret `GOKR_WEATHER_API_KEY` when calling the API.
+of each ballpark to one or more nearby CCTV IDs lives in
+`public/data/stadiumCctvIds.json`. The update script queries each ID in order and
+uses the most recent result, falling back to "정보없음" when no fresh data is
+available. The workflow uses the secret `GOKR_WEATHER_API_KEY` when calling the
+API.
 
 © 2025 직관가자. All rights reserved.
 Created and maintained by Sumin Lee.

--- a/update_weather.py
+++ b/update_weather.py
@@ -9,43 +9,76 @@ SERVICE_KEY = os.environ.get("GOKR_WEATHER_API_KEY")
 if not SERVICE_KEY:
     raise SystemExit("GOKR_WEATHER_API_KEY environment variable not set")
 
-with open("public/data/ballpark_weather_sources.json", "r", encoding="utf-8") as f:
+with open("public/data/stadiumCctvIds.json", "r", encoding="utf-8") as f:
     sources = json.load(f)
+
+kst = timezone(timedelta(hours=9))
+now = datetime.now(kst)
 
 results = []
 for item in sources:
-    params = {
-        "serviceKey": SERVICE_KEY,
-        "pageNo": "1",
-        "numOfRows": "1",
-        "dataType": "JSON",
-        "eqmtId": item["eqmtId"],
-        "hhCode": "00",
-    }
-    try:
-        resp = requests.get(BASE_URL, params=params, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
-        weather = (
-            data.get("response", {})
-            .get("body", {})
-            .get("items", {})
-            .get("item", [{}])[0]
-            .get("weatherNm", "정보없음")
-        )
-    except Exception as e:
-        print("Failed to fetch", item["eqmtId"], e)
-        weather = "정보없음"
-    results.append({
-        "team": item["team"],
-        "stadium": item["stadium"],
-        "weatherNm": weather,
-        "eqmtId": item["eqmtId"],
-    })
+    eqmt_ids = item.get("eqmtIds") or [item.get("eqmtId")]
+    eqmt_ids = [e for e in eqmt_ids if e]
+    if not eqmt_ids:
+        continue
 
-kst = timezone(timedelta(hours=9))
+    weather = "정보없음"
+    used_id = eqmt_ids[0]
+
+    for eqmt_id in eqmt_ids:
+        params = {
+            "serviceKey": SERVICE_KEY,
+            "pageNo": "1",
+            "numOfRows": "1",
+            "dataType": "JSON",
+            "eqmtId": eqmt_id,
+            "hhCode": "00",
+        }
+        try:
+            resp = requests.get(BASE_URL, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            items = (
+                data.get("response", {})
+                .get("body", {})
+                .get("items", {})
+                .get("item", [])
+            )
+            if not items:
+                continue
+            info = items[0]
+            w = info.get("weatherNm", "정보없음")
+            base_date = info.get("baseDate")
+            base_time = info.get("baseTime")
+            base_dt = None
+            if base_date and base_time:
+                try:
+                    base_dt = datetime.strptime(
+                        base_date + base_time, "%Y%m%d%H%M"
+                    ).replace(tzinfo=kst)
+                except ValueError:
+                    base_dt = None
+
+            if w != "정보없음" and (
+                base_dt is None or now - base_dt <= timedelta(hours=2)
+            ):
+                weather = w
+                used_id = eqmt_id
+                break
+        except Exception as e:
+            print("Failed to fetch", eqmt_id, e)
+
+    results.append(
+        {
+            "team": item["team"],
+            "stadium": item.get("stadiumName") or item.get("stadium"),
+            "weatherNm": weather,
+            "eqmtId": used_id,
+        }
+    )
+
 output = {
-    "updatedAt": datetime.now(kst).isoformat(),
+    "updatedAt": now.isoformat(),
     "data": results,
 }
 


### PR DESCRIPTION
## Summary
- switch `update_weather.py` to `stadiumCctvIds.json`
- try multiple CCTV IDs and ignore stale data
- document new behaviour in README

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*
- `python update_weather.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687a75cd39208331b8bb194fbc6b7cbc