### PR TITLE
Refactor weather updater to use urllib

### DIFF
--- a/update_weather.py
+++ b/update_weather.py
@@ -1,7 +1,8 @@
 import json
 import os
 from datetime import datetime, timezone, timedelta
-import requests
+from urllib.parse import urlencode
+from urllib.request import urlopen
 
 BASE_URL = "https://apis.data.go.kr/1360000/RoadWthrInfoService/getCctvStnRoadWthr"
 SERVICE_KEY = os.environ.get("GOKR_WEATHER_API_KEY")
@@ -35,9 +36,9 @@ for item in sources:
             "hhCode": "00",
         }
         try:
-            resp = requests.get(BASE_URL, params=params, timeout=10)
-            resp.raise_for_status()
-            data = resp.json()
+            url = BASE_URL + "?" + urlencode(params)
+            with urlopen(url, timeout=10) as resp:
+                data = json.load(resp)
             items = (
                 data.get("response", {})
                 .get("body", {})


### PR DESCRIPTION
## Summary
- fix update_weather.py to not depend on `requests`
- use Python's builtin urllib to call the public API

## Testing
- `npm test` *(fails: react-scripts not found)*
- `GOKR_WEATHER_API_KEY=demo python update_weather.py` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a788af20c8331ad13a97170b4db95