### PR TITLE
Add short-term forecast script and clean up schedule weather

### DIFF
--- a/ballparkLocations.json
+++ b/ballparkLocations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "team": "LG Twins / Doosan Bears",
+    "stadium": "서울 잠실야구장",
+    "lat": 37.512106,
+    "lon": 127.072744,
+    "nx": 61,
+    "ny": 126
+  },
+  {
+    "team": "Kiwoom Heroes",
+    "stadium": "서울 고척스카이돔",
+    "lat": 37.49804,
+    "lon": 126.867744,
+    "nx": 58,
+    "ny": 125
+  },
+  {
+    "team": "SSG Landers",
+    "stadium": "인천 SSG랜더스필드",
+    "lat": 37.435105,
+    "lon": 126.693977,
+    "nx": 55,
+    "ny": 124
+  },
+  {
+    "team": "KT Wiz",
+    "stadium": "수원 KT 위즈파크",
+    "lat": 37.299845,
+    "lon": 127.009532,
+    "nx": 60,
+    "ny": 121
+  },
+  {
+    "team": "Hanwha Eagles",
+    "stadium": "대전 한화생명이글스파크",
+    "lat": 36.317181,
+    "lon": 127.428123,
+    "nx": 68,
+    "ny": 100
+  },
+  {
+    "team": "KIA Tigers",
+    "stadium": "광주 기아 챔피언스 필드",
+    "lat": 35.168255,
+    "lon": 126.888108,
+    "nx": 59,
+    "ny": 75
+  },
+  {
+    "team": "Samsung Lions",
+    "stadium": "대구 삼성라이온즈파크",
+    "lat": 35.841992,
+    "lon": 128.681314,
+    "nx": 90,
+    "ny": 90
+  },
+  {
+    "team": "NC Dinos",
+    "stadium": "창원 NC파크",
+    "lat": 35.219483,
+    "lon": 128.582719,
+    "nx": 89,
+    "ny": 76
+  },
+  {
+    "team": "Lotte Giants",
+    "stadium": "부산 사직야구장",
+    "lat": 35.194505,
+    "lon": 129.059052,
+    "nx": 98,
+    "ny": 76
+  }
+]

--- a/fetch_short_term_weather.py
+++ b/fetch_short_term_weather.py
@@ -1,0 +1,71 @@
+import requests
+import json
+import os
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("GOKR_WEATHER_API_KEY")
+BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+
+with open("ballparkLocations.json", encoding="utf-8") as f:
+    ballparks = json.load(f)
+
+
+def get_base_datetime():
+    now = datetime.now()
+    base_times = ["2300", "2000", "1700", "1400", "1100", "0800", "0500", "0200"]
+    for bt in base_times:
+        hour = int(bt[:2])
+        base = now.replace(hour=hour, minute=0, second=0, microsecond=0)
+        if now >= base:
+            return base.strftime("%Y%m%d"), bt
+    base = now - timedelta(days=1)
+    return base.strftime("%Y%m%d"), "2300"
+
+
+base_date, base_time = get_base_datetime()
+
+results = []
+for park in ballparks:
+    nx, ny = park["nx"], park["ny"]
+    params = {
+        "serviceKey": API_KEY,
+        "pageNo": "1",
+        "numOfRows": "1000",
+        "dataType": "JSON",
+        "base_date": base_date,
+        "base_time": base_time,
+        "nx": nx,
+        "ny": ny,
+    }
+    try:
+        resp = requests.get(BASE_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        items = data["response"]["body"]["items"]["item"]
+        forecast = {}
+        for item in items:
+            fcst_time = item["fcstTime"]
+            if fcst_time not in forecast:
+                forecast[fcst_time] = {}
+            forecast[fcst_time][item["category"]] = item["fcstValue"]
+
+        results.append({
+            "team": park["team"],
+            "stadium": park["stadium"],
+            "location": {"nx": nx, "ny": ny},
+            "forecasts": forecast,
+        })
+        print(f"✅ Success: {park['stadium']}")
+    except Exception as e:
+        print(f"❌ Failed: {park['stadium']} / {e}")
+
+output = {
+    "updatedAt": datetime.now().isoformat(),
+    "data": results,
+}
+
+with open("public/data/kboBallparkForecast.json", "w", encoding="utf-8") as f:
+    json.dump(output, f, ensure_ascii=False, indent=2)

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,7 +6,7 @@ const Footer = () => (
     <br />
     Created and maintained by Sumin Lee.
     <br />
-    Road weather data © Korea Meteorological Administration.
+    Weather data © Korea Meteorological Administration.
     <br />
     <a
       href="mailto:jikgwangaza@gmail.com?subject=Bug%20Report"

--- a/src/components/ScheduleTab.jsx
+++ b/src/components/ScheduleTab.jsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Calendar } from 'lucide-react';
 import { getTeamInfo } from '../utils/team';
-import useBallparkWeather from '../hooks/useBallparkWeather';
 
 const ALL_TEAMS = [
   'KIA',
@@ -25,7 +24,6 @@ const ScheduleTab = ({
   teamRanks,
 }) => {
   const [locationFilter, setLocationFilter] = useState('전체');
-  const weatherMap = useBallparkWeather();
 
   const getRank = (team) => {
     const r = teamRanks?.find((t) => t.team === team);
@@ -123,9 +121,6 @@ const ScheduleTab = ({
             <div className="text-sm text-right text-gray-600 dark:text-gray-300 leading-snug">
               <div>
                 {game.location || getTeamInfo(game.home).stadium}
-                {weatherMap[game.location || getTeamInfo(game.home).stadium]
-                  ? ` • ${weatherMap[game.location || getTeamInfo(game.home).stadium]}`
-                  : ''}
               </div>
               <div>
                 {formatDateKorean(game.date)}


### PR DESCRIPTION
## Summary
- add `ballparkLocations.json` with grid coordinates
- new `fetch_short_term_weather.py` script saves forecast data
- drop old weather references from ScheduleTab
- update footer wording

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0348cbd48331b7ded6fb9561b60e