### PR TITLE
Add ballpark weather display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -220,6 +220,7 @@ const JikgwanGaja = () => {
     teamRanks,
     teamRankTime,
     allStarData,
+    ballparkForecast,
   } = useKboData();
   const [currentLineup, setCurrentLineup] = useState([]);
   const gameDatesForTeam = useMemo(
@@ -965,6 +966,7 @@ const getSortedChants = () => {
                 teamRanks={teamRanks}
                 getDisplayName={getDisplayName}
                 allStarData={allStarData}
+                ballparkForecast={ballparkForecast}
               />
             )}
             {activeTab === 'teamChants' && (

--- a/src/components/BallparkWeather.jsx
+++ b/src/components/BallparkWeather.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+
+const BallparkWeather = ({ forecast, gameTime }) => {
+  if (!forecast || !gameTime) return null;
+
+  const parseMinutes = (t) => {
+    const str = t.toString().padStart(4, '0');
+    return parseInt(str.slice(0, 2), 10) * 60 + parseInt(str.slice(2), 10);
+  };
+
+  const match = gameTime.match(/(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+  const gameMin = parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+
+  const times = Object.keys(forecast.forecasts || {});
+  if (times.length === 0) return null;
+  let selected = times[0];
+  let minDiff = Math.abs(parseMinutes(selected) - gameMin);
+  times.forEach((t) => {
+    const diff = Math.abs(parseMinutes(t) - gameMin);
+    if (diff < minDiff) {
+      selected = t;
+      minDiff = diff;
+    }
+  });
+
+  const data = forecast.forecasts[selected];
+  if (!data) return null;
+
+  const skyMap = { '1': '맑음', '3': '구름많음', '4': '흐림' };
+  const ptyMap = { '0': '', '1': '비', '2': '비/눈', '3': '눈', '4': '소나기' };
+
+  const sky = skyMap[data.SKY] || '';
+  const pty = ptyMap[data.PTY] || '';
+  const timeLabel = `${selected.slice(0, 2)}:${selected.slice(2)}`;
+
+  return (
+    <div className="mt-3 text-sm bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded-lg p-3">
+      <div className="flex items-center gap-1 font-semibold mb-1">
+        <MapPin className="w-4 h-4" />
+        {forecast.stadium} {timeLabel}
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        <span>{sky}{pty ? ` ${pty}` : ''}</span>
+        <span>{data.TMP}℃</span>
+        <span>강수확률 {data.POP}%</span>
+        {data.PCP && data.PCP !== '강수없음' && <span>{data.PCP}</span>}
+        <span>습도 {data.REH}%</span>
+        {data.WSD && <span>풍속 {data.WSD}m/s</span>}
+      </div>
+    </div>
+  );
+};
+
+export default BallparkWeather;

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PlayerCard from './PlayerCard';
 import StartingPitcherCard from './StartingPitcherCard';
 import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
+import BallparkWeather from './BallparkWeather';
 import { getTeamInfo } from '../utils/team';
 
 const LineupTab = ({
@@ -29,6 +30,7 @@ const LineupTab = ({
   teamRanks,
   getDisplayName,
   allStarData,
+  ballparkForecast,
 }) => {
   const currentGame = getCurrentGame();
   const [allStarTeam, setAllStarTeam] = useState('dream');
@@ -37,6 +39,13 @@ const LineupTab = ({
     const r = teamRanks?.find((t) => t.team === team);
     return r ? `${r.rank}위` : '';
   };
+
+  const forecast =
+    currentGame && ballparkForecast?.data
+      ? ballparkForecast.data.find((f) =>
+          f.team.includes(getTeamInfo(currentGame.home).fullNameEn)
+        )
+      : null;
 
   const renderAllStarSection = (title, items) => (
     <div className="mb-4">
@@ -219,6 +228,7 @@ const LineupTab = ({
               </div>
             </div>
           </div>
+          <BallparkWeather forecast={forecast} gameTime={currentGame.gameTime} />
 
           {currentGame.canceled ? (
             <div className="text-center py-8 text-gray-500">

--- a/src/hooks/useKboData.js
+++ b/src/hooks/useKboData.js
@@ -100,6 +100,7 @@ const useKboData = () => {
   const [teamRanks, setTeamRanks] = useState([]);
   const [teamRankTime, setTeamRankTime] = useState(null);
   const [allStarData, setAllStarData] = useState(null);
+  const [ballparkForecast, setBallparkForecast] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -120,7 +121,7 @@ const useKboData = () => {
     try {
       const base = process.env.PUBLIC_URL || '';
 
-      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, allStar] = await Promise.all([
+      const [songsData, lineupIndex, teamChantsData, kboPlayersData, fallbackLineups, teamRankData, allStar, ballparkForecastData] = await Promise.all([
         fetchSafeJson(`${base}/data/playerSongs.json`, []),
         fetchSafeJson(`${base}/data/kbo_crawler_data/index.json`, null),
         fetchSafeJson(`${base}/data/teamChants.json`, []),
@@ -128,6 +129,7 @@ const useKboData = () => {
         fetchSafeJson(`${base}/data/gameLineups.json`, []),
         fetchSafeJson(`${base}/data/teamRank.json`, { results: [] }),
         fetchSafeJson(`${base}/data/allStar2025.json`, null),
+        fetchSafeJson(`${base}/data/kboBallparkForecast.json`, null),
       ]);
 
       console.log('로드된 데이터:', {
@@ -137,6 +139,7 @@ const useKboData = () => {
         kboPlayersCount: kboPlayersData?.length,
         teamRankCount: teamRankData?.results?.length,
         allStarLoaded: !!allStar,
+        ballparkForecastLoaded: !!ballparkForecastData,
       });
 
       const parsedKboPlayers = Array.isArray(kboPlayersData) ? kboPlayersData : [];
@@ -423,6 +426,7 @@ const useKboData = () => {
       setTeamRanks(ranks);
       setTeamRankTime(teamRankData?.crawl_time || null);
       setAllStarData(allStar);
+      setBallparkForecast(ballparkForecastData);
 
       console.log('최종 설정된 데이터:', {
         playerSongs: parsedSongs.length,
@@ -430,6 +434,7 @@ const useKboData = () => {
         teamChants: parsedTeamChants.length,
         teamRanks: ranks.length,
         allStar: allStar ? 'loaded' : 'none',
+        ballparkForecast: ballparkForecastData ? 'loaded' : 'none',
       });
 
     } catch (err) {
@@ -456,6 +461,7 @@ const useKboData = () => {
     teamRanks,
     teamRankTime,
     allStarData,
+    ballparkForecast,
   };
 };
 


### PR DESCRIPTION
## Summary
- fetch ballpark forecast data in `useKboData`
- create `BallparkWeather` component
- show game-day weather info on lineup tab

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0b118ec08331bb7e04eae46ac6f8