### PR TITLE
Add ballpark weather modal

### DIFF
--- a/src/components/BallparkWeatherModal.jsx
+++ b/src/components/BallparkWeatherModal.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+const BallparkWeatherModal = ({ forecast, onClose }) => {
+  if (!forecast) return null;
+
+  const skyMap = { '1': '맑음', '3': '구름많음', '4': '흐림' };
+  const ptyMap = { '0': '', '1': '비', '2': '비/눈', '3': '눈', '4': '소나기' };
+
+  const entries = Object.entries(forecast.forecasts || {}).sort(
+    ([a], [b]) => parseInt(a) - parseInt(b)
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl m-4 p-4 w-full max-w-md">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="font-bold text-lg">{forecast.stadium} 날씨</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="overflow-y-auto max-h-[70vh]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-200">
+                <th className="p-2 text-center">시간</th>
+                <th className="p-2 text-center">날씨</th>
+                <th className="p-2 text-center">기온</th>
+                <th className="p-2 text-center">강수확률</th>
+                <th className="p-2 text-center">강수량</th>
+                <th className="p-2 text-center">습도</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {entries.map(([time, d]) => {
+                const sky = skyMap[d.SKY] || '';
+                const pty = ptyMap[d.PTY] || '';
+                const pcp = d.PCP && d.PCP !== '강수없음' ? d.PCP : '';
+                return (
+                  <tr key={time} className="bg-white dark:bg-gray-800">
+                    <td className="p-2 text-center">{time.slice(0,2)}:{time.slice(2)}</td>
+                    <td className="p-2 text-center">{sky}{pty ? ` ${pty}` : ''}</td>
+                    <td className="p-2 text-center">{d.TMP}℃</td>
+                    <td className="p-2 text-center">{d.POP}%</td>
+                    <td className="p-2 text-center">{pcp}</td>
+                    <td className="p-2 text-center">{d.REH}%</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BallparkWeatherModal;

--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import PlayerCard from './PlayerCard';
 import StartingPitcherCard from './StartingPitcherCard';
-import { RefreshCw, AlertCircle, Music, Circle, Share2 } from 'lucide-react';
+import { RefreshCw, AlertCircle, Music, Circle, Share2, CloudSun } from 'lucide-react';
 import BallparkWeather from './BallparkWeather';
+import BallparkWeatherModal from './BallparkWeatherModal';
 import { getTeamInfo } from '../utils/team';
 
 const LineupTab = ({
@@ -34,6 +35,7 @@ const LineupTab = ({
 }) => {
   const currentGame = getCurrentGame();
   const [allStarTeam, setAllStarTeam] = useState('dream');
+  const [showWeather, setShowWeather] = useState(false);
   const isAllStarDay = selectedDate === '2025-07-12';
   const getRank = (team) => {
     const r = teamRanks?.find((t) => t.team === team);
@@ -229,6 +231,17 @@ const LineupTab = ({
             </div>
           </div>
           <BallparkWeather forecast={forecast} gameTime={currentGame.gameTime} />
+          {forecast && (
+            <button
+              onClick={() => setShowWeather(true)}
+              className="mt-2 flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              <CloudSun className="w-4 h-4" /> 구장 날씨 보기
+            </button>
+          )}
+          {showWeather && (
+            <BallparkWeatherModal forecast={forecast} onClose={() => setShowWeather(false)} />
+          )}
 
           {currentGame.canceled ? (
             <div className="text-center py-8 text-gray-500">


### PR DESCRIPTION
## Summary
- add a new `BallparkWeatherModal` component to show full forecast
- show a "구장 날씨 보기" button on the lineup screen

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b299cc6b083318eca4ddedcbd761e