### PR TITLE
Limit weather display to current date

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -42,8 +42,19 @@ const LineupTab = ({
     return r ? `${r.rank}위` : '';
   };
 
+  const isWeatherToday =
+    ballparkForecast?.updatedAt &&
+    new Date(ballparkForecast.updatedAt).toDateString() ===
+      new Date().toDateString();
+
+  const isSelectedDateToday =
+    new Date(selectedDate).toDateString() === new Date().toDateString();
+
   const forecast =
-    currentGame && ballparkForecast?.data
+    currentGame &&
+    ballparkForecast?.data &&
+    isWeatherToday &&
+    isSelectedDateToday
       ? ballparkForecast.data.find((f) =>
           f.team.includes(getTeamInfo(currentGame.home).fullNameEn)
         )


### PR DESCRIPTION
## Summary
- update LineupTab to only show weather when forecast data is for today and the user selected today's lineup

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2c15c0348331bf426aa2ce08af75