### PR TITLE
Remove duplicate stadium from lineup info

### DIFF
--- a/src/components/LineupTab.jsx
+++ b/src/components/LineupTab.jsx
@@ -205,9 +205,6 @@ const LineupTab = ({
                 </div>
                 <div className="text-sm text-gray-600 dark:text-gray-300 leading-snug">
                   <div>
-                    {currentGame.location || getTeamInfo(currentGame.home).stadium}
-                  </div>
-                  <div>
                     {formatDateKorean(currentGame.date)}
                     {(() => {
                       const isCanceled =


### PR DESCRIPTION
## Summary
- stop showing ballpark name in the lineup header

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b3aa34a288331b3aef656dfb88c46