### PR TITLE
Add weather update workflow

### DIFF
--- a/.github/workflows/weather-crawl.yml
+++ b/.github/workflows/weather-crawl.yml
@@ -1,0 +1,40 @@
+name: Daily KBO ballpark weather
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests python-dotenv
+
+      - name: Fetch short-term weather
+        env:
+          GOKR_WEATHER_API_KEY: ${{ secrets.GOKR_WEATHER_API_KEY }}
+        run: python fetch_short_term_weather.py
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add public/data/kboBallparkForecast.json
+          git commit -m "Daily weather update" || echo "No changes to commit"
+          git pull --rebase origin main
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -112,12 +112,13 @@ python public/kbo_schedule_crawler.py --start 2025-03-25 --end 2025-03-30 --outp
 
 ## Automated daily crawl
 
-Four GitHub Actions workflows keep the data updated:
+Five GitHub Actions workflows keep the data updated:
 
 - `.github/workflows/lineup-crawl.yml` fetches new lineups several times each day and rebuilds `public/data/kbo_crawler_data/index.json`.
 - `.github/workflows/player-crawl.yml` updates `public/data/kboPlayers.json` daily at 00:00 UTC.
 - `.github/workflows/team-rank-crawl.yml` refreshes `public/data/teamRank.json` once per day.
 - `.github/workflows/schedule-crawl.yml` updates `public/data/kboSchedule.json` once per day.
+- `.github/workflows/weather-crawl.yml` refreshes `public/data/kboBallparkForecast.json` hourly.
 
 All workflows commit any changes back to the repository automatically.
 


### PR DESCRIPTION
## Summary
- automate short-term weather updates for ballparks via GitHub Actions
- document the new workflow in README

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7e6e2dd08331a13cfd55b5287dc2