### PR TITLE
Avoid calendar highlight for cancelled games

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -230,7 +230,13 @@ const JikgwanGaja = () => {
           .filter((game) => {
             const parts = game.id.split('_');
             const team = parts[parts.length - 1];
-            return parts.length >= 2 && team === selectedTeam;
+            const isCanceled = game.canceled ||
+              (game.gameStatus && game.gameStatus.includes('취소'));
+            return (
+              parts.length >= 2 &&
+              team === selectedTeam &&
+              !isCanceled
+            );
           })
           .map((game) => game.id.split('_')[0])
       ),


### PR DESCRIPTION
## Summary
- prevent cancelled games from contributing to highlighted dates on the calendar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c87ec9d34833194048de65ec046f4