### PR TITLE
Improve weather fetch reliability

### DIFF
--- a/fetch_short_term_weather.py
+++ b/fetch_short_term_weather.py
@@ -1,7 +1,9 @@
-import requests
 import json
 import os
+import time
 from datetime import datetime, timedelta
+
+import requests
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -27,6 +29,16 @@ def get_base_datetime():
 
 base_date, base_time = get_base_datetime()
 
+prev_map = {}
+prev_path = "public/data/kboBallparkForecast.json"
+if os.path.exists(prev_path):
+    try:
+        with open(prev_path, encoding="utf-8") as f:
+            prev_json = json.load(f)
+            prev_map = {p["stadium"]: p for p in prev_json.get("data", [])}
+    except Exception:
+        prev_map = {}
+
 results = []
 for park in ballparks:
     nx, ny = park["nx"], park["ny"]
@@ -40,27 +52,45 @@ for park in ballparks:
         "nx": nx,
         "ny": ny,
     }
-    try:
-        resp = requests.get(BASE_URL, params=params, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
-        items = data["response"]["body"]["items"]["item"]
-        forecast = {}
-        for item in items:
-            fcst_time = item["fcstTime"]
-            if fcst_time not in forecast:
-                forecast[fcst_time] = {}
-            forecast[fcst_time][item["category"]] = item["fcstValue"]
 
-        results.append({
-            "team": park["team"],
-            "stadium": park["stadium"],
-            "location": {"nx": nx, "ny": ny},
-            "forecasts": forecast,
-        })
-        print(f"✅ Success: {park['stadium']}")
-    except Exception as e:
-        print(f"❌ Failed: {park['stadium']} / {e}")
+    entry = None
+    for attempt in range(2):
+        try:
+            resp = requests.get(BASE_URL, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            items = data["response"]["body"]["items"]["item"]
+            forecast = {}
+            for item in items:
+                fcst_time = item["fcstTime"]
+                if fcst_time not in forecast:
+                    forecast[fcst_time] = {}
+                forecast[fcst_time][item["category"]] = item["fcstValue"]
+
+            entry = {
+                "team": park["team"],
+                "stadium": park["stadium"],
+                "location": {"nx": nx, "ny": ny},
+                "forecasts": forecast,
+            }
+            if attempt == 0:
+                print(f"✅ Success: {park['stadium']}")
+            else:
+                print(f"✅ Success on retry: {park['stadium']}")
+            break
+        except Exception as e:
+            if attempt == 0:
+                print(f"❌ Failed: {park['stadium']} / {e} -> retrying")
+                time.sleep(1)
+            else:
+                print(f"❌ Failed again: {park['stadium']} / {e}")
+                if park["stadium"] in prev_map:
+                    entry = prev_map[park["stadium"]]
+                    print(f"↩️  Using previous data for {park['stadium']}")
+                else:
+                    print(f"⚠️  No previous data for {park['stadium']}")
+    if entry:
+        results.append(entry)
 
 output = {
     "updatedAt": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary
- retain previous ballpark weather forecasts
- retry failed requests once for each stadium

## Testing
- `python -m py_compile fetch_short_term_weather.py`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688475a936648331b7cb044d80b2bfe2